### PR TITLE
Fixed bug with models apart from LSTMs

### DIFF
--- a/word_language_model/model.py
+++ b/word_language_model/model.py
@@ -37,4 +37,4 @@ class RNNModel(nn.Container):
             return (Variable(weight.new(self.nlayers, bsz, self.nhid).zero_()),
                     Variable(weight.new(self.nlayers, bsz, self.nhid).zero_()))
         else:
-            return Variable(weight.new(args.nlayers, bsz, args.nhid).zero_())
+            return Variable(weight.new(self.nlayers, bsz, self.nhid).zero_())


### PR DESCRIPTION
args isn't defined in the model file so this doesn't work for RNNs that aren't LSTMs.