### PR TITLE
Make mnist_hogwild python 2.7 compatible

### DIFF
--- a/mnist_hogwild/main.py
+++ b/mnist_hogwild/main.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import os, argparse
 import torch
-import sys
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.multiprocessing as mp
@@ -46,8 +45,6 @@ class Net(nn.Module):
         return F.log_softmax(x)
 
 if __name__ == '__main__':
-    if sys.version_info.major == 3:
-        mp.set_start_method('spawn')
     args = parser.parse_args()
 
     torch.manual_seed(args.seed)

--- a/mnist_hogwild/main.py
+++ b/mnist_hogwild/main.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import os, argparse
 import torch
+import sys
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.multiprocessing as mp

--- a/mnist_hogwild/main.py
+++ b/mnist_hogwild/main.py
@@ -45,7 +45,8 @@ class Net(nn.Module):
         return F.log_softmax(x)
 
 if __name__ == '__main__':
-    mp.set_start_method('spawn')
+    if sys.version_info.major == 3:
+        mp.set_start_method('spawn')
     args = parser.parse_args()
 
     torch.manual_seed(args.seed)


### PR DESCRIPTION
multiprocessing in python 2.7 doesn't support multiprocessing.set_start_method method - so we'll skip it