### PR TITLE
Remove module names from arch list in Imagenet example

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -15,7 +15,8 @@ import torchvision.models as models
 
 
 model_names = sorted(name for name in models.__dict__
-    if name.islower() and not name.startswith("__"))
+    if name.islower() and not name.startswith("__")
+    and callable(models.__dict__[name]))
 
 
 parser = argparse.ArgumentParser(description='PyTorch ImageNet Training')


### PR DESCRIPTION
PR #28 had a bug that it listed models' module names (i.e. vgg, resnet) among the architectures. This PR fixes the problem.