### PR TITLE
Prevent 2 forward passes with detach

### DIFF
--- a/dcgan/main.py
+++ b/dcgan/main.py
@@ -213,9 +213,9 @@ for epoch in range(opt.niter):
         # train with fake
         noise.data.resize_(batch_size, nz, 1, 1)
         noise.data.normal_(0, 1)
-        fake = netG(noise).detach()
+        fake = netG(noise)
         label.data.fill_(fake_label)
-        output = netD(fake)
+        output = netD(fake.detach())
         errD_fake = criterion(output, label)
         errD_fake.backward()
         D_G_z1 = output.data.mean()
@@ -227,8 +227,6 @@ for epoch in range(opt.niter):
         ###########################
         netG.zero_grad()
         label.data.fill_(real_label) # fake labels are real for generator cost
-        noise.data.normal_(0, 1)
-        fake = netG(noise)
         output = netD(fake)
         errG = criterion(output, label)
         errG.backward()


### PR DESCRIPTION
Similarly to the Torch example, this reuses the fake image that was created for the discriminator (and hence the forward pass of the generator).

Checked that the expected backwards passes are occurring using hooks, and have also run the example to check that it's working fine empirically.