### PR TITLE
Mnist example using specified GPU

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import argparse
+import sys
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -19,14 +20,21 @@ parser.add_argument('--lr', type=float, default=0.01, metavar='LR',
                     help='learning rate (default: 0.01)')
 parser.add_argument('--momentum', type=float, default=0.5, metavar='M',
                     help='SGD momentum (default: 0.5)')
-parser.add_argument('--no-cuda', action='store_true', default=False,
-                    help='enables CUDA training')
+parser.add_argument('--gpu', type=int,
+                    help='gpu id to be used. -1 represents cpu mode.')
 parser.add_argument('--seed', type=int, default=1, metavar='S',
                     help='random seed (default: 1)')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                     help='how many batches to wait before logging training status')
 args = parser.parse_args()
-args.cuda = not args.no_cuda and torch.cuda.is_available()
+
+args.cuda = torch.cuda.is_available()
+if args.gpu is not None:
+    if args.gpu < 0:
+        args.cuda = False
+    elif not args.cuda:
+        print('GPU id is specified but cuda is unavailable,'
+              ' so running on CPU mode.', file=sys.stderr)
 
 torch.manual_seed(args.seed)
 if args.cuda:
@@ -69,6 +77,7 @@ class Net(nn.Module):
 
 model = Net()
 if args.cuda:
+    torch.cuda.set_device(args.gpu)
     model.cuda()
 
 optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)


### PR DESCRIPTION
Currently it does not only use specified gpu, but also use gpu id 0 (as shown below).
Is this a expected behavior, or am I missing something?
I also tried passing `args.gpu` to all `.cuda()` function like `model.cuda(args.gpu)`, but it does not change the behavior compared to that using `torch.cuda.set_device(args.gpu)`.

**gpu id == 1**

```
% python main.py --gpu 1

% nvidia-smi
Tue Feb 21 04:25:45 2017
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 367.57                 Driver Version: 367.57                    |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|===============================+======================+======================|
|   0  TITAN X (Pascal)    Off  | 0000:05:00.0      On |                  N/A |
| 23%   36C    P8    12W / 250W |    459MiB / 12188MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   1  TITAN X (Pascal)    Off  | 0000:06:00.0     Off |                  N/A |
| 23%   39C    P8    17W / 250W |      3MiB / 12189MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   2  TITAN X (Pascal)    Off  | 0000:09:00.0     Off |                  N/A |
| 23%   45C    P2    58W / 250W |    380MiB / 12189MiB |     19%      Default |
+-------------------------------+----------------------+----------------------+
|   3  TITAN X (Pascal)    Off  | 0000:0A:00.0     Off |                  N/A |
| 23%   31C    P8    16W / 250W |    288MiB / 12189MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                       GPU Memory |
|  GPU       PID  Type  Process name                               Usage      |
|=============================================================================|
|    0      1255    G   /usr/lib/xorg/Xorg                             230MiB |
|    0      2874    G   compiz                                         216MiB |
|    0      8586    G   ...nDeveloperModeWarning/Default/Html5ByDefa     8MiB |
|    2     26563    C   python                                         377MiB |
|    3     26563    C   python                                         285MiB |
+-----------------------------------------------------------------------------+
```

**gpu id == 0**

```
% python main.py --gpu 0

% nvidia-smi
Tue Feb 21 04:27:31 2017
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 367.57                 Driver Version: 367.57                    |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|===============================+======================+======================|
|   0  TITAN X (Pascal)    Off  | 0000:05:00.0      On |                  N/A |
| 23%   36C    P8    12W / 250W |    459MiB / 12188MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   1  TITAN X (Pascal)    Off  | 0000:06:00.0     Off |                  N/A |
| 23%   39C    P8    17W / 250W |      3MiB / 12189MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   2  TITAN X (Pascal)    Off  | 0000:09:00.0     Off |                  N/A |
| 25%   42C    P8    17W / 250W |      3MiB / 12189MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   3  TITAN X (Pascal)    Off  | 0000:0A:00.0     Off |                  N/A |
| 23%   30C    P2    56W / 250W |    380MiB / 12189MiB |     18%      Default |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                       GPU Memory |
|  GPU       PID  Type  Process name                               Usage      |
|=============================================================================|
|    0      1255    G   /usr/lib/xorg/Xorg                             230MiB |
|    0      2874    G   compiz                                         216MiB |
|    0      8586    G   ...nDeveloperModeWarning/Default/Html5ByDefa     8MiB |
|    3     27820    C   python                                         377MiB |
+-----------------------------------------------------------------------------+
```