### PR TITLE
fixed divide by zero error

### DIFF
--- a/reinforcement_learning/actor_critic.py
+++ b/reinforcement_learning/actor_critic.py
@@ -69,7 +69,7 @@ def finish_episode():
         R = r + args.gamma * R
         rewards.insert(0, R)
     rewards = torch.Tensor(rewards)
-    rewards = (rewards - rewards.mean()) / rewards.std()
+    rewards = (rewards - rewards.mean()) / (rewards.std() + np.finfo(np.float32).eps)
     for (action, value), r in zip(saved_actions, rewards):
         action.reinforce(r - value.data.squeeze())
         value_loss += F.smooth_l1_loss(value, Variable(torch.Tensor([r])))

--- a/reinforcement_learning/reinforce.py
+++ b/reinforcement_learning/reinforce.py
@@ -65,7 +65,7 @@ def finish_episode():
         R = r + args.gamma * R
         rewards.insert(0, R)
     rewards = torch.Tensor(rewards)
-    rewards = (rewards - rewards.mean()) / rewards.std()
+    rewards = (rewards - rewards.mean()) / (rewards.std() + np.finfo(np.float32).eps)
     for action, r in zip(model.saved_actions, rewards):
         action.reinforce(r)
     optimizer.zero_grad()


### PR DESCRIPTION
If the agent never experienced reward, rewards turns into nan (0/0). We should add machine epsilon to the denominator here to avoid that.