### PR TITLE
ONMT fixes and updates

### DIFF
--- a/OpenNMT/.gitignore
+++ b/OpenNMT/.gitignore
@@ -1,0 +1,3 @@
+pred.txt
+multi-bleu.perl
+*.pt

--- a/OpenNMT/README.md
+++ b/OpenNMT/README.md
@@ -32,19 +32,19 @@ Use of OpenNMT consists of four steps:
 
 ```perl multi-bleu.perl data/tgt-test.txt < demo_pred.txt```
 
-## WMT'16 Multimodal Translation: Flickr30k (de-en)
+## WMT'16 Multimodal Translation: Multi30k (de-en)
 
-Data might not come as clean as the demo data. Here is a second example that uses the Moses tokenizer (http://www.statmt.org/moses/) to prepare the Flickr30k data from the WMT'16 Multimodal Translation task (http://www.statmt.org/wmt16/multimodal-task.html).
+Data might not come as clean as the demo data. Here is a second example that uses the Moses tokenizer (http://www.statmt.org/moses/) to prepare the Multi30k data from the WMT'16 Multimodal Translation task (http://www.statmt.org/wmt16/multimodal-task.html).
 
 ### 0) Download the data.
 
-```mkdir -p data/flickr```
+```mkdir -p data/multi30k```
 
-```wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/training.tar.gz &&  tar -xf training.tar.gz -C data/flickr && rm training.tar.gz```
+```wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/training.tar.gz &&  tar -xf training.tar.gz -C data/multi30k && rm training.tar.gz```
 
-```wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz && tar -xf validation.tar.gz -C data/flickr && rm validation.tar.gz```
+```wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz && tar -xf validation.tar.gz -C data/multi30k && rm validation.tar.gz```
 
-```wget https://staff.fnwi.uva.nl/d.elliott/wmt16/mmt16_task1_test.tgz && tar -xf mmt16_task1_test.tgz -C data/flickr && rm mmt16_task1_test.tgz```
+```wget https://staff.fnwi.uva.nl/d.elliott/wmt16/mmt16_task1_test.tgz && tar -xf mmt16_task1_test.tgz -C data/multi30k && rm mmt16_task1_test.tgz```
 
 ### 1) Preprocess the data.
 
@@ -56,24 +56,23 @@ Data might not come as clean as the demo data. Here is a second example that use
 
 ```wget https://github.com/moses-smt/mosesdecoder/blob/master/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.en```
 
-```for l in en de; do for f in data/flickr/*.$l; do if [[ "$f" != *"test"* ]]; then sed -i "$ d" $f; fi; perl tokenizer.perl -no-escape -l $l -q  < $f > $f.tok; done; done```
+```for l in en de; do for f in data/multi30k/*.$l; do if [[ "$f" != *"test"* ]]; then sed -i "$ d" $f; fi; perl tokenizer.perl -no-escape -l $l -q  < $f > $f.tok; done; done```
 
-```python preprocess.py -train_src data/flickr/train.en.tok -train_tgt data/flickr/train.de.tok -valid_src data/flickr/val.en.tok -valid_tgt data/flickr/val.de.tok -save_data data/flickr```
+```python preprocess.py -train_src data/multi30k/train.en.tok -train_tgt data/multi30k/train.de.tok -valid_src data/multi30k/val.en.tok -valid_tgt data/multi30k/val.de.tok -save_data data/multi30k```
 
 ### 2) Train the model.
 
-```python train.py -data data/flickr-train.pt -save_model flickr_model -gpus 0```
+```python train.py -data data/multi30k-train.pt -save_model multi30k_model -gpus 0```
 
 ### 3) Translate sentences.
 
-```python translate.py -gpu 0 -model flickr_model_e7_*.pt -src data/flickr/test.en.tok -tgt data/flickr/test.de.tok -replace_unk -verbose -output flickr_pred.txt```
->>>>>>> c87fc08... tips for non-demo mt via flickr30k example
+```python translate.py -gpu 0 -model multi30k_model_e13_*.pt -src data/multi30k/test.en.tok -tgt data/multi30k/test.de.tok -replace_unk -verbose -output multi30k_pred.txt```
 
 ### 4) Evaluate.
 
 ```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/generic/multi-bleu.perl```
 
-```perl multi-bleu.perl data/flickr/test.de < flickr_pred.txt```
+```perl multi-bleu.perl data/multi30k/test.de.tok < multi30k_pred.txt```
 
 ## Pretrained Models
 

--- a/OpenNMT/README.md
+++ b/OpenNMT/README.md
@@ -20,11 +20,12 @@ OpenNMT consists of three commands:
 
 2) Train the model.
 
-```python train.py -data data/demo-train.pt -save_model model -gpus 1```
+```python train.py -data data/demo-train.pt -save_model model -gpus 0```
 
 3) Translate sentences.
 
-```python translate.py -gpu 1 -model model_e13_*.pt -src data/src-test.txt -tgt data/tgt-test.txt -replace_unk -verbose```
+```python translate.py -gpu 0 -model model_e13_*.pt -src data/src-test.txt -tgt data/tgt-test.txt -replace_unk -verbose```
+>>>>>>> c19b7d3... README changes for multi-gpu
 
 ## Pretrained Models
 

--- a/OpenNMT/README.md
+++ b/OpenNMT/README.md
@@ -29,6 +29,7 @@ Use of OpenNMT consists of four steps:
 ### 4) Evaluate.
 
 ```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/generic/multi-bleu.perl```
+
 ```perl multi-bleu.perl data/tgt-test.txt < demo_pred.txt```
 
 ## WMT'16 Multimodal Translation: Flickr30k (de-en)
@@ -71,6 +72,7 @@ Data might not come as clean as the demo data. Here is a second example that use
 ### 4) Evaluate.
 
 ```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/generic/multi-bleu.perl```
+
 ```perl multi-bleu.perl data/flickr/test.de < flickr_pred.txt```
 
 ## Pretrained Models

--- a/OpenNMT/README.md
+++ b/OpenNMT/README.md
@@ -28,9 +28,10 @@ Use of OpenNMT consists of four steps:
 
 ### 4) Evaluate.
 
-```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/generic/multi-bleu.perl```
-
-```perl multi-bleu.perl data/tgt-test.txt < demo_pred.txt```
+```bash
+wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/generic/multi-bleu.perl
+perl multi-bleu.perl data/tgt-test.txt < demo_pred.txt
+```
 
 ## WMT'16 Multimodal Translation: Multi30k (de-en)
 
@@ -38,27 +39,23 @@ Data might not come as clean as the demo data. Here is a second example that use
 
 ### 0) Download the data.
 
-```mkdir -p data/multi30k```
-
-```wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/training.tar.gz &&  tar -xf training.tar.gz -C data/multi30k && rm training.tar.gz```
-
-```wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz && tar -xf validation.tar.gz -C data/multi30k && rm validation.tar.gz```
-
-```wget https://staff.fnwi.uva.nl/d.elliott/wmt16/mmt16_task1_test.tgz && tar -xf mmt16_task1_test.tgz -C data/multi30k && rm mmt16_task1_test.tgz```
+```bash
+mkdir -p data/multi30k
+wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/training.tar.gz &&  tar -xf training.tar.gz -C data/multi30k && rm training.tar.gz
+wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz && tar -xf validation.tar.gz -C data/multi30k && rm validation.tar.gz
+wget https://staff.fnwi.uva.nl/d.elliott/wmt16/mmt16_task1_test.tgz && tar -xf mmt16_task1_test.tgz -C data/multi30k && rm mmt16_task1_test.tgz
+```
 
 ### 1) Preprocess the data.
 
-```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/tokenizer/tokenizer.perl```
-
-```sed -i "s/$RealBin\/..\/share\/nonbreaking_prefixes//" tokenizer.perl```
-
-```wget https://github.com/moses-smt/mosesdecoder/blob/master/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.de```
-
-```wget https://github.com/moses-smt/mosesdecoder/blob/master/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.en```
-
-```for l in en de; do for f in data/multi30k/*.$l; do if [[ "$f" != *"test"* ]]; then sed -i "$ d" $f; fi; perl tokenizer.perl -no-escape -l $l -q  < $f > $f.tok; done; done```
-
-```python preprocess.py -train_src data/multi30k/train.en.tok -train_tgt data/multi30k/train.de.tok -valid_src data/multi30k/val.en.tok -valid_tgt data/multi30k/val.de.tok -save_data data/multi30k```
+```bash
+wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/tokenizer/tokenizer.perl
+sed -i "s/$RealBin\/..\/share\/nonbreaking_prefixes//" tokenizer.perl
+wget https://github.com/moses-smt/mosesdecoder/blob/master/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.de
+wget https://github.com/moses-smt/mosesdecoder/blob/master/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.en
+for l in en de; do for f in data/multi30k/*.$l; do if [[ "$f" != *"test"* ]]; then sed -i "$ d" $f; fi; perl tokenizer.perl -no-escape -l $l -q  < $f > $f.tok; done; done
+python preprocess.py -train_src data/multi30k/train.en.tok -train_tgt data/multi30k/train.de.tok -valid_src data/multi30k/val.en.tok -valid_tgt data/multi30k/val.de.tok -save_data data/multi30k
+```
 
 ### 2) Train the model.
 
@@ -70,9 +67,10 @@ Data might not come as clean as the demo data. Here is a second example that use
 
 ### 4) Evaluate.
 
-```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/generic/multi-bleu.perl```
-
-```perl multi-bleu.perl data/multi30k/test.de.tok < multi30k_pred.txt```
+```bash
+wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/generic/multi-bleu.perl
+perl multi-bleu.perl data/multi30k/test.de.tok < multi30k_pred.txt
+```
 
 ## Pretrained Models
 

--- a/OpenNMT/README.md
+++ b/OpenNMT/README.md
@@ -19,8 +19,11 @@ Demo:
 Flickr30k (de-en):
 
 ```mkdir -p data/flickr```
+
 ```wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/training.tar.gz &&  tar -xf training.tar.gz -C data/flickr && rm training.tar.gz```
+
 ```wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz && tar -xf validation.tar.gz -C data/flickr && rm validation.tar.gz```
+
 ```wget https://staff.fnwi.uva.nl/d.elliott/wmt16/mmt16_task1_test.tgz && tar -xf mmt16_task1_test.tgz -C data/flickr && rm mmt16_task1_test.tgz```
 
 1) Preprocess the data.
@@ -32,10 +35,15 @@ Demo:
 Flickr30k:
 
 ```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/tokenizer/tokenizer.perl```
+
 ```sed -i "s/$RealBin\/..\/share\/nonbreaking_prefixes//" tokenizer.perl```
+
 ```wget https://github.com/moses-smt/mosesdecoder/blob/master/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.de```
+
 ```wget https://github.com/moses-smt/mosesdecoder/blob/master/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.en```
+
 ```for l in en de; do for f in data/flickr/*.$l; do if [[ "$f" != *"test"* ]]; then sed -i "$ d" $f; fi; perl tokenizer.perl -no-escape -l $l -q  < $f > $f.tok; done; done```
+
 ```python preprocess.py -train_src data/flickr/train.en.tok -train_tgt data/flickr/train.de.tok -valid_src data/flickr/val.en.tok -valid_tgt data/flickr/val.de.tok -save_data data/flickr```
 
 2) Train the model.

--- a/OpenNMT/README.md
+++ b/OpenNMT/README.md
@@ -8,15 +8,34 @@ an open-source (MIT) neural machine translation system.
 
 ## Quickstart
 
-OpenNMT consists of three commands:
+Use of OpenNMT consists of four steps:
 
-0) Download the data.
-
-Demo:
+### 0) Download the data.
 
 ```wget https://s3.amazonaws.com/pytorch/examples/opennmt/data/onmt-data.tar && tar -xf onmt-data.tar```
 
-Flickr30k (de-en):
+### 1) Preprocess the data.
+
+```python preprocess.py -train_src data/src-train.txt -train_tgt data/tgt-train.txt -valid_src data/src-val.txt -valid_tgt data/tgt-val.txt -save_data data/demo```
+
+### 2) Train the model.
+
+```python train.py -data data/demo-train.pt -save_model demo_model -gpus 0```
+
+### 3) Translate sentences.
+
+```python translate.py -gpu 0 -model demo_model_e13_*.pt -src data/src-test.txt -tgt data/tgt-test.txt -replace_unk -verbose -output demo_pred.txt```
+
+### 4) Evaluate.
+
+```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/generic/multi-bleu.perl```
+```perl multi-bleu.perl data/tgt-test.txt < demo_pred.txt```
+
+## WMT'16 Multimodal Translation: Flickr30k (de-en)
+
+Data might not come as clean as the demo data. Here is a second example that uses the Moses tokenizer (http://www.statmt.org/moses/) to prepare the Flickr30k data from the WMT'16 Multimodal Translation task (http://www.statmt.org/wmt16/multimodal-task.html).
+
+### 0) Download the data.
 
 ```mkdir -p data/flickr```
 
@@ -26,13 +45,7 @@ Flickr30k (de-en):
 
 ```wget https://staff.fnwi.uva.nl/d.elliott/wmt16/mmt16_task1_test.tgz && tar -xf mmt16_task1_test.tgz -C data/flickr && rm mmt16_task1_test.tgz```
 
-1) Preprocess the data.
-
-Demo:
-
-```python preprocess.py -train_src data/src-train.txt -train_tgt data/tgt-train.txt -valid_src data/src-val.txt -valid_tgt data/tgt-val.txt -save_data data/demo```
-
-Flickr30k:
+### 1) Preprocess the data.
 
 ```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/tokenizer/tokenizer.perl```
 
@@ -46,37 +59,18 @@ Flickr30k:
 
 ```python preprocess.py -train_src data/flickr/train.en.tok -train_tgt data/flickr/train.de.tok -valid_src data/flickr/val.en.tok -valid_tgt data/flickr/val.de.tok -save_data data/flickr```
 
-2) Train the model.
-
-Demo:
-
-```python train.py -data data/demo-train.pt -save_model model -gpus 0```
-
-Flickr30k:
+### 2) Train the model.
 
 ```python train.py -data data/flickr-train.pt -save_model flickr_model -gpus 0```
 
-3) Translate sentences.
-
-Demo:
-
-```python translate.py -gpu 0 -model model_e13_*.pt -src data/src-test.txt -tgt data/tgt-test.txt -replace_unk -verbose -output demo-pred.txt```
-
-Flickr30k:
+### 3) Translate sentences.
 
 ```python translate.py -gpu 0 -model flickr_model_e7_*.pt -src data/flickr/test.en.tok -tgt data/flickr/test.de.tok -replace_unk -verbose -output flickr_pred.txt```
 >>>>>>> c87fc08... tips for non-demo mt via flickr30k example
 
-4) Evaluate.
+### 4) Evaluate.
 
 ```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/generic/multi-bleu.perl```
-
-Demo:
-
-```perl multi-bleu.perl data/tgt-test.txt < pred.txt```
-
-Flickr30k:
-
 ```perl multi-bleu.perl data/flickr/test.de < flickr_pred.txt```
 
 ## Pretrained Models

--- a/OpenNMT/README.md
+++ b/OpenNMT/README.md
@@ -27,6 +27,11 @@ OpenNMT consists of three commands:
 ```python translate.py -gpu 0 -model model_e13_*.pt -src data/src-test.txt -tgt data/tgt-test.txt -replace_unk -verbose```
 >>>>>>> c19b7d3... README changes for multi-gpu
 
+4) Evaluate.
+
+```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/generic/multi-bleu.perl```
+```perl multi-bleu.perl data/tgt-test.txt < pred.txt```
+
 ## Pretrained Models
 
 The following pretrained models can be downloaded and used with translate.py.

--- a/OpenNMT/README.md
+++ b/OpenNMT/README.md
@@ -12,25 +12,64 @@ OpenNMT consists of three commands:
 
 0) Download the data.
 
+Demo:
+
 ```wget https://s3.amazonaws.com/pytorch/examples/opennmt/data/onmt-data.tar && tar -xf onmt-data.tar```
+
+Flickr30k (de-en):
+
+```mkdir -p data/flickr```
+```wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/training.tar.gz &&  tar -xf training.tar.gz -C data/flickr && rm training.tar.gz```
+```wget http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz && tar -xf validation.tar.gz -C data/flickr && rm validation.tar.gz```
+```wget https://staff.fnwi.uva.nl/d.elliott/wmt16/mmt16_task1_test.tgz && tar -xf mmt16_task1_test.tgz -C data/flickr && rm mmt16_task1_test.tgz```
 
 1) Preprocess the data.
 
+Demo:
+
 ```python preprocess.py -train_src data/src-train.txt -train_tgt data/tgt-train.txt -valid_src data/src-val.txt -valid_tgt data/tgt-val.txt -save_data data/demo```
+
+Flickr30k:
+
+```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/tokenizer/tokenizer.perl```
+```sed -i "s/$RealBin\/..\/share\/nonbreaking_prefixes//" tokenizer.perl```
+```wget https://github.com/moses-smt/mosesdecoder/blob/master/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.de```
+```wget https://github.com/moses-smt/mosesdecoder/blob/master/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.en```
+```for l in en de; do for f in data/flickr/*.$l; do if [[ "$f" != *"test"* ]]; then sed -i "$ d" $f; fi; perl tokenizer.perl -no-escape -l $l -q  < $f > $f.tok; done; done```
+```python preprocess.py -train_src data/flickr/train.en.tok -train_tgt data/flickr/train.de.tok -valid_src data/flickr/val.en.tok -valid_tgt data/flickr/val.de.tok -save_data data/flickr```
 
 2) Train the model.
 
+Demo:
+
 ```python train.py -data data/demo-train.pt -save_model model -gpus 0```
+
+Flickr30k:
+
+```python train.py -data data/flickr-train.pt -save_model flickr_model -gpus 0```
 
 3) Translate sentences.
 
-```python translate.py -gpu 0 -model model_e13_*.pt -src data/src-test.txt -tgt data/tgt-test.txt -replace_unk -verbose```
->>>>>>> c19b7d3... README changes for multi-gpu
+Demo:
+
+```python translate.py -gpu 0 -model model_e13_*.pt -src data/src-test.txt -tgt data/tgt-test.txt -replace_unk -verbose -output demo-pred.txt```
+
+Flickr30k:
+
+```python translate.py -gpu 0 -model flickr_model_e7_*.pt -src data/flickr/test.en.tok -tgt data/flickr/test.de.tok -replace_unk -verbose -output flickr_pred.txt```
+>>>>>>> c87fc08... tips for non-demo mt via flickr30k example
 
 4) Evaluate.
 
 ```wget https://raw.githubusercontent.com/moses-smt/mosesdecoder/master/scripts/generic/multi-bleu.perl```
+
+Demo:
+
 ```perl multi-bleu.perl data/tgt-test.txt < pred.txt```
+
+Flickr30k:
+
+```perl multi-bleu.perl data/flickr/test.de < flickr_pred.txt```
 
 ## Pretrained Models
 

--- a/OpenNMT/onmt/Dataset.py
+++ b/OpenNMT/onmt/Dataset.py
@@ -1,3 +1,5 @@
+import random
+
 import onmt
 from torch.autograd import Variable
 
@@ -46,3 +48,9 @@ class Dataset(object):
 
     def __len__(self):
         return self.numBatches
+
+
+    def shuffle(self):
+        zipped = list(zip(self.src, self.tgt))
+        random.shuffle(zipped)
+        self.src, self.tgt = [x[0] for x in zipped], [x[1] for x in zipped]

--- a/OpenNMT/onmt/Dataset.py
+++ b/OpenNMT/onmt/Dataset.py
@@ -1,3 +1,4 @@
+import math
 import random
 
 import onmt
@@ -16,7 +17,7 @@ class Dataset(object):
         self.cuda = cuda
 
         self.batchSize = batchSize
-        self.numBatches = len(self.src) // batchSize
+        self.numBatches = math.ceil(len(self.src)/batchSize)
         self.volatile = volatile
 
     def _batchify(self, data, align_right=False):

--- a/OpenNMT/onmt/Dataset.py
+++ b/OpenNMT/onmt/Dataset.py
@@ -6,7 +6,7 @@ from torch.autograd import Variable
 
 class Dataset(object):
 
-    def __init__(self, srcData, tgtData, batchSize, cuda):
+    def __init__(self, srcData, tgtData, batchSize, cuda, volatile=False):
         self.src = srcData
         if tgtData:
             self.tgt = tgtData
@@ -16,7 +16,8 @@ class Dataset(object):
         self.cuda = cuda
 
         self.batchSize = batchSize
-        self.numBatches = (len(self.src) + batchSize - 1) // batchSize
+        self.numBatches = len(self.src) // batchSize
+        self.volatile = volatile
 
     def _batchify(self, data, align_right=False):
         max_length = max(x.size(0) for x in data)
@@ -30,7 +31,7 @@ class Dataset(object):
         if self.cuda:
             out = out.cuda()
 
-        v = Variable(out)
+        v = Variable(out, volatile=self.volatile)
         return v
 
     def __getitem__(self, index):

--- a/OpenNMT/onmt/Dict.py
+++ b/OpenNMT/onmt/Dict.py
@@ -2,10 +2,11 @@ import torch
 
 
 class Dict(object):
-    def __init__(self, data=None):
+    def __init__(self, data=None, lower=False):
         self.idxToLabel = {}
         self.labelToIdx = {}
         self.frequencies = {}
+        self.lower = True
 
         # Special entries will not be pruned.
         self.special = []
@@ -37,6 +38,7 @@ class Dict(object):
         file.close()
 
     def lookup(self, key, default=None):
+        key = key.lower() if self.lower else key
         try:
             return self.labelToIdx[key]
         except KeyError:
@@ -60,6 +62,7 @@ class Dict(object):
 
     # Add `label` in the dictionary. Use `idx` as its index if given.
     def add(self, label, idx=None):
+        label = label.lower() if self.lower else label
         if idx is not None:
             self.idxToLabel[idx] = label
             self.labelToIdx[label] = idx

--- a/OpenNMT/onmt/Dict.py
+++ b/OpenNMT/onmt/Dict.py
@@ -6,7 +6,7 @@ class Dict(object):
         self.idxToLabel = {}
         self.labelToIdx = {}
         self.frequencies = {}
-        self.lower = True
+        self.lower = lower
 
         # Special entries will not be pruned.
         self.special = []

--- a/OpenNMT/onmt/Dict.py
+++ b/OpenNMT/onmt/Dict.py
@@ -92,6 +92,7 @@ class Dict(object):
         _, idx = torch.sort(freq, 0, True)
 
         newDict = Dict()
+        newDict.lower = self.lower
 
         # Add special entries in all cases.
         for i in self.special:

--- a/OpenNMT/onmt/Models.py
+++ b/OpenNMT/onmt/Models.py
@@ -149,7 +149,7 @@ class NMTModel(nn.Module):
                       self._fix_enc_hidden(enc_hidden[1]))
 
         out, dec_hidden, _attn = self.decoder(tgt, enc_hidden, context, init_output)
-        if hasattr(self, 'generate') and self.generate:
+        if hasattr(self, 'generator') and self.generate:
             out = self.generator(out)
 
         return out

--- a/OpenNMT/onmt/Models.py
+++ b/OpenNMT/onmt/Models.py
@@ -115,11 +115,10 @@ class Decoder(nn.Module):
 
 class NMTModel(nn.Module):
 
-    def __init__(self, encoder, decoder, generator):
+    def __init__(self, encoder, decoder):
         super(NMTModel, self).__init__()
         self.encoder = encoder
         self.decoder = decoder
-        self.generator = generator
         self.generate = False
 
     def set_generate(self, enabled):
@@ -150,7 +149,7 @@ class NMTModel(nn.Module):
                       self._fix_enc_hidden(enc_hidden[1]))
 
         out, dec_hidden, _attn = self.decoder(tgt, enc_hidden, context, init_output)
-        if self.generate:
+        if hasattr(self, 'generate') and self.generate:
             out = self.generator(out)
 
         return out

--- a/OpenNMT/onmt/Models.py
+++ b/OpenNMT/onmt/Models.py
@@ -114,13 +114,13 @@ class Decoder(nn.Module):
             if self.input_feed:
                 emb_t = torch.cat([emb_t, output], 1)
 
-            output, h = self.rnn(emb_t, hidden)
+            output, hidden = self.rnn(emb_t, hidden)
             output, attn = self.attn(output, context.t())
             output = self.dropout(output)
             outputs += [output]
 
         outputs = torch.stack(outputs)
-        return outputs.transpose(0, 1), h, attn
+        return outputs.transpose(0, 1), hidden, attn
 
 
 class NMTModel(nn.Module):

--- a/OpenNMT/onmt/Models.py
+++ b/OpenNMT/onmt/Models.py
@@ -94,10 +94,6 @@ class Decoder(nn.Module):
     def forward(self, input, hidden, context, init_output):
         emb = self.word_lut(input)
 
-        batch_size = input.size(1)
-
-        h_size = (batch_size, self.hidden_size)
-
         # n.b. you can increase performance if you compute W_ih * x for all
         # iterations in parallel, but that's only possible if
         # self.input_feed=False

--- a/OpenNMT/onmt/Models.py
+++ b/OpenNMT/onmt/Models.py
@@ -46,17 +46,16 @@ class StackedLSTM(nn.Module):
         super(StackedLSTM, self).__init__()
         self.dropout = nn.Dropout(dropout)
         self.num_layers = num_layers
+        self.layers = nn.ModuleList()
 
         for i in range(num_layers):
-            layer = nn.LSTMCell(input_size, rnn_size)
-            self.add_module('layer_%d' % i, layer)
+            self.layers.append(nn.LSTMCell(input_size, rnn_size))
             input_size = rnn_size
 
     def forward(self, input, hidden):
         h_0, c_0 = hidden
         h_1, c_1 = [], []
-        for i in range(self.num_layers):
-            layer = getattr(self, 'layer_%d' % i)
+        for i, layer in enumerate(self.layers):
             h_1_i, c_1_i = layer(input, (h_0[i], c_0[i]))
             input = h_1_i
             if i != self.num_layers:

--- a/OpenNMT/onmt/Models.py
+++ b/OpenNMT/onmt/Models.py
@@ -38,6 +38,34 @@ class Encoder(nn.Module):
         return hidden_t, outputs
 
 
+class StackedLSTM(nn.Module):
+    def __init__(self, num_layers, input_size, rnn_size, dropout):
+        super(StackedLSTM, self).__init__()
+        self.dropout = nn.Dropout(dropout)
+        self.num_layers = num_layers
+        self.layers = nn.ModuleList()
+
+        for i in range(num_layers):
+            self.layers.append(nn.LSTMCell(input_size, rnn_size))
+            input_size = rnn_size
+
+    def forward(self, input, hidden):
+        h_0, c_0 = hidden
+        h_1, c_1 = [], []
+        for i, layer in enumerate(self.layers):
+            h_1_i, c_1_i = layer(input, (h_0[i], c_0[i]))
+            input = h_1_i
+            if i != self.num_layers:
+                input = self.dropout(input)
+            h_1 += [h_1_i]
+            c_1 += [c_1_i]
+
+        h_1 = torch.stack(h_1)
+        c_1 = torch.stack(c_1)
+
+        return input, (h_1, c_1)
+
+
 class Decoder(nn.Module):
 
     def __init__(self, opt, dicts):
@@ -51,9 +79,7 @@ class Decoder(nn.Module):
         self.word_lut = nn.Embedding(dicts.size(),
                                   opt.word_vec_size,
                                   padding_idx=onmt.Constants.PAD)
-        self.rnn = nn.LSTM(input_size, opt.rnn_size, 
-                        num_layers=opt.layers,
-                        dropout=opt.dropout)
+        self.rnn = StackedLSTM(opt.layers, input_size, opt.rnn_size, opt.dropout)
         self.attn = onmt.modules.GlobalAttention(opt.rnn_size)
         self.dropout = nn.Dropout(opt.dropout)
 
@@ -77,16 +103,16 @@ class Decoder(nn.Module):
         outputs = []
         output = init_output
         for i, emb_t in enumerate(emb.split(1)):
-            emb_t = emb_t
+            emb_t = emb_t.squeeze(0)
             if self.input_feed:
-                emb_t = torch.cat([emb_t, output], 2)
+                emb_t = torch.cat([emb_t, output], 1)
 
             output, hidden = self.rnn(emb_t, hidden)
-            output, attn = self.attn(output.squeeze(0), context.t())
-            output = self.dropout(output.unsqueeze(0))
+            output, attn = self.attn(output, context.t())
+            output = self.dropout(output)
             outputs += [output]
 
-        outputs = torch.cat(outputs, 0)
+        outputs = torch.stack(outputs)
         return outputs.transpose(0, 1), hidden, attn
 
 
@@ -105,7 +131,7 @@ class NMTModel(nn.Module):
     def make_init_decoder_output(self, context):
         batch_size = context.size(1)
         h_size = (batch_size, self.decoder.hidden_size)
-        return Variable(context.data.new(1, *h_size).zero_(), requires_grad=False)
+        return Variable(context.data.new(*h_size).zero_(), requires_grad=False)
 
     def _fix_enc_hidden(self, h):
         #  the encoder hidden is  (layers*directions) x batch x dim

--- a/OpenNMT/onmt/Models.py
+++ b/OpenNMT/onmt/Models.py
@@ -110,7 +110,7 @@ class Decoder(nn.Module):
         # self.input_feed=False
         outputs = []
         output = init_output
-        for i, emb_t in enumerate(emb.chunk(emb.size(0), dim=0)):
+        for i, emb_t in enumerate(emb.split(1)):
             emb_t = emb_t.squeeze(0)
             if self.input_feed:
                 emb_t = torch.cat([emb_t, output], 1)

--- a/OpenNMT/onmt/Optim.py
+++ b/OpenNMT/onmt/Optim.py
@@ -1,5 +1,7 @@
 import math
 import torch.optim as optim
+import torch.nn as nn
+from torch.nn.utils import clip_grad_norm
 
 class Optim(object):
 
@@ -29,19 +31,9 @@ class Optim(object):
 
     def step(self):
         # Compute gradients norm.
-        grad_norm = 0
-        for param in self.params:
-            grad_norm += math.pow(param.grad.data.norm(), 2)
-
-        grad_norm = math.sqrt(grad_norm)
-        shrinkage = self.max_grad_norm / grad_norm
-
-        for param in self.params:
-            if shrinkage < 1:
-                param.grad.data.mul_(shrinkage)
-
+        if self.max_grad_norm:
+            clip_grad_norm(self.params, self.max_grad_norm)
         self.optimizer.step()
-        return grad_norm
 
     # decay learning rate if val perf does not improve or we hit the start_decay_at limit
     def updateLearningRate(self, ppl, epoch):

--- a/OpenNMT/onmt/Translator.py
+++ b/OpenNMT/onmt/Translator.py
@@ -48,7 +48,7 @@ class Translator(object):
 
     def translateBatch(self, batch):
         srcBatch, tgtBatch = batch
-        batchSize = srcBatch.size(0)
+        batchSize = srcBatch.size(1)
         beamSize = self.opt.beam_size
 
         #  (1) run the encoder on the src
@@ -56,9 +56,9 @@ class Translator(object):
         # have to execute the encoder manually to deal with padding
         encStates = None
         context = []
-        for srcBatch_t in srcBatch.chunk(srcBatch.size(1), dim=1):
+        for srcBatch_t in srcBatch.split(1):
             encStates, context_t = self.model.encoder(srcBatch_t, hidden=encStates)
-            batchPadIdx = srcBatch_t.data.squeeze(1).eq(onmt.Constants.PAD).nonzero()
+            batchPadIdx = srcBatch_t.data.squeeze(0).eq(onmt.Constants.PAD).nonzero()
             if batchPadIdx.nelement() > 0:
                 batchPadIdx = batchPadIdx.squeeze(1)
                 encStates[0].data.index_fill_(1, batchPadIdx, 0)
@@ -73,7 +73,7 @@ class Translator(object):
 
         #  This mask is applied to the attention model inside the decoder
         #  so that the attention ignores source padding
-        padMask = srcBatch.data.eq(onmt.Constants.PAD)
+        padMask = srcBatch.data.eq(onmt.Constants.PAD).t()
         def applyContextMask(m):
             if isinstance(m, onmt.modules.GlobalAttention):
                 m.applyMask(padMask)
@@ -88,8 +88,8 @@ class Translator(object):
             initOutput = self.model.make_init_decoder_output(context)
 
             decOut, decStates, attn = self.model.decoder(
-                    tgtBatch[:, :-1], decStates, context, initOutput)
-            for dec_t, tgt_t in zip(decOut.transpose(0, 1), tgtBatch.transpose(0, 1)[1:].data):
+                tgtBatch[:-1], decStates, context, initOutput)
+            for dec_t, tgt_t in zip(decOut, tgtBatch[1:].data):
                 gen_t = self.model.generator.forward(dec_t)
                 tgt_t = tgt_t.unsqueeze(1)
                 scores = gen_t.data.gather(1, tgt_t)
@@ -107,7 +107,7 @@ class Translator(object):
 
         decOut = self.model.make_init_decoder_output(context)
 
-        padMask = srcBatch.data.eq(onmt.Constants.PAD).unsqueeze(0).repeat(beamSize, 1, 1)
+        padMask = srcBatch.data.eq(onmt.Constants.PAD).t().unsqueeze(0).repeat(beamSize, 1, 1)
 
         batchIdx = list(range(batchSize))
         remainingSents = batchSize
@@ -120,9 +120,9 @@ class Translator(object):
                                if not b.done]).t().contiguous().view(1, -1)
 
             decOut, decStates, attn = self.model.decoder(
-                Variable(input, volatile=True).transpose(0, 1), decStates, context, decOut)
+                Variable(input, volatile=True), decStates, context, decOut)
             # decOut: 1 x (beam*batch) x numWords
-            decOut = decOut.transpose(0, 1).squeeze(0)
+            decOut = decOut.squeeze(0)
             out = self.model.generator.forward(decOut)
 
             # batch x beam x numWords
@@ -177,7 +177,7 @@ class Translator(object):
             scores, ks = beam[b].sortBest()
 
             allScores += [scores[:n_best]]
-            valid_attn = srcBatch.transpose(0, 1).data[:, b].ne(onmt.Constants.PAD).nonzero().squeeze(1)
+            valid_attn = srcBatch.data[:, b].ne(onmt.Constants.PAD).nonzero().squeeze(1)
             hyps, attn = zip(*[beam[b].getHyp(k) for k in ks[:n_best]])
             attn = [a.index_select(1, valid_attn) for a in attn]
             allHyp += [hyps]
@@ -189,14 +189,13 @@ class Translator(object):
         #  (1) convert words to indexes
         dataset = self.buildData(srcBatch, goldBatch)
         batch = dataset[0]
-        batch = [x.transpose(0, 1) for x in batch]
 
         #  (2) translate
         pred, predScore, attn, goldScore = self.translateBatch(batch)
 
         #  (3) convert indexes to words
         predBatch = []
-        for b in range(batch[0].size(0)):
+        for b in range(batch[0].size(1)):
             predBatch.append(
                 [self.buildTargetTokens(pred[b][n], srcBatch[b], attn[b][n])
                         for n in range(self.opt.n_best)]

--- a/OpenNMT/onmt/modules/GlobalAttention.py
+++ b/OpenNMT/onmt/modules/GlobalAttention.py
@@ -24,8 +24,6 @@ import torch
 import torch.nn as nn
 import math
 
-_INF = float('inf')
-
 class GlobalAttention(nn.Module):
     def __init__(self, dim):
         super(GlobalAttention, self).__init__()
@@ -48,7 +46,7 @@ class GlobalAttention(nn.Module):
         # Get attention
         attn = torch.bmm(context, targetT).squeeze(2)  # batch x sourceL
         if self.mask is not None:
-            attn.data.masked_fill_(self.mask, -_INF)
+            attn.data.masked_fill_(self.mask, -float('inf'))
         attn = self.sm(attn)
         attn3 = attn.view(attn.size(0), 1, attn.size(1))  # batch x 1 x sourceL
 

--- a/OpenNMT/preprocess.py
+++ b/OpenNMT/preprocess.py
@@ -50,7 +50,7 @@ opt = parser.parse_args()
 
 def makeVocabulary(filename, size):
     vocab = onmt.Dict([onmt.Constants.PAD_WORD, onmt.Constants.UNK_WORD,
-                       onmt.Constants.BOS_WORD, onmt.Constants.EOS_WORD], lower=True)
+                       onmt.Constants.BOS_WORD, onmt.Constants.EOS_WORD], lower=opt.lower)
 
     with open(filename) as f:
         for sent in f.readlines():

--- a/OpenNMT/preprocess.py
+++ b/OpenNMT/preprocess.py
@@ -40,6 +40,8 @@ parser.add_argument('-shuffle',    type=int, default=1,
 parser.add_argument('-seed',       type=int, default=3435,
                     help="Random seed")
 
+parser.add_argument('-lower', action='store_true', help='lowercase data')
+
 parser.add_argument('-report_every', type=int, default=100000,
                     help="Report status every this many sentences")
 
@@ -48,7 +50,7 @@ opt = parser.parse_args()
 
 def makeVocabulary(filename, size):
     vocab = onmt.Dict([onmt.Constants.PAD_WORD, onmt.Constants.UNK_WORD,
-                       onmt.Constants.BOS_WORD, onmt.Constants.EOS_WORD])
+                       onmt.Constants.BOS_WORD, onmt.Constants.EOS_WORD], lower=True)
 
     with open(filename) as f:
         for sent in f.readlines():

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -180,7 +180,7 @@ def trainModel(model, trainData, validData, dataset, optim):
     start_time = time.time()
     def trainEpoch(epoch):
 
-        if opt.extra_shuffle and epoch >= opt.curriculum:
+        if opt.extra_shuffle and epoch > opt.curriculum:
             trainData.shuffle()
 
         # shuffle mini batch order
@@ -192,7 +192,7 @@ def trainModel(model, trainData, validData, dataset, optim):
         start = time.time()
         for i in range(len(trainData)):
 
-            batchIdx = batchOrder[i] if epoch >= opt.curriculum else i
+            batchIdx = batchOrder[i] if epoch > opt.curriculum else i
             batch = trainData[batchIdx]
 
             model.zero_grad()

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -71,7 +71,7 @@ parser.add_argument('-learning_rate_decay', type=float, default=0.5,
                     help="""Decay learning rate by this much if (i) perplexity
                     does not decrease on the validation set or (ii) epoch has
                     gone past the start_decay_at_limit""")
-parser.add_argument('-start_decay_at', default=8,
+parser.add_argument('-start_decay_at', type=int, default=8,
                     help="Start decay after this epoch")
 parser.add_argument('-curriculum', action="store_true",
                     help="""For this many epochs, order the minibatches based

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -213,7 +213,7 @@ def trainModel(model, trainData, validData, dataset, optim):
             total_words += num_words
             report_tgt_words += num_words
             report_src_words += batch[0].data.ne(onmt.Constants.PAD).sum()
-            if i % opt.log_interval == 0 and i > 0:
+            if i % opt.log_interval == -1 % opt.log_interval:
                 print("Epoch %2d, %5d/%5d; acc: %6.2f; ppl: %6.2f; %3.0f src tok/s; %3.0f tgt tok/s; %6.0f s elapsed" %
                       (epoch, i, len(trainData),
                       num_correct / num_words * 100,

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -229,7 +229,7 @@ def trainModel(model, trainData, validData, dataset, optim):
             'optim': optim,
         }
         torch.save(checkpoint,
-                   '%s_val%.2f_e%d_train%.2f.pt' % (opt.save_model, valid_ppl, epoch, train_ppl))
+                   '%s_val%.2f_train%.2f_e%d.pt' % (opt.save_model, valid_ppl, train_ppl, epoch))
 
 def main():
 

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -166,7 +166,7 @@ def trainModel(model, trainData, validData, dataset, optim):
         batchOrder = torch.randperm(len(trainData))
 
         total_loss, report_loss = 0, 0
-        total_words, report_words = 0, 0
+        total_words, report_tgt_words, report_src_words = 0, 0, 0
         start = time.time()
         for i in range(len(trainData)):
 
@@ -189,15 +189,17 @@ def trainModel(model, trainData, validData, dataset, optim):
             total_loss += loss
             num_words = targets.data.ne(onmt.Constants.PAD).sum()
             total_words += num_words
-            report_words += num_words
+            report_tgt_words += num_words
+            report_src_words += batch[0].data.ne(onmt.Constants.PAD).sum()
             if i % opt.log_interval == 0 and i > 0:
-                print("Epoch %2d, %5d/%5d batches; perplexity: %6.2f; %3.0f tokens/s; %6.0f s elapsed" %
+                print("Epoch %2d, %5d/%5d batches; perplexity: %6.2f; %3.0f source tokens/s; %3.0f target tokens/s; %6.0f s elapsed" %
                       (epoch, i, len(trainData),
-                      math.exp(report_loss / report_words),
-                      report_words/(time.time()-start),
+                      math.exp(report_loss / report_tgt_words),
+                      report_src_words/(time.time()-start),
+                      report_tgt_words/(time.time()-start),
                       time.time()-start_time))
 
-                report_loss = report_words = 0
+                report_loss = report_tgt_words = report_src_words = 0
                 start = time.time()
 
         return total_loss / total_words

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -269,7 +269,8 @@ def main():
     trainData = onmt.Dataset(dataset['train']['src'],
                              dataset['train']['tgt'], opt.batch_size, opt.gpus)
     validData = onmt.Dataset(dataset['valid']['src'],
-                             dataset['valid']['tgt'], opt.batch_size, opt.gpus)
+                             dataset['valid']['tgt'], opt.batch_size, opt.gpus,
+                             volatile=True)
 
     dicts = dataset['dicts']
     print(' * vocabulary size. source = %d; target = %d' %

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -214,10 +214,10 @@ def trainModel(model, trainData, validData, dataset, optim):
             report_tgt_words += num_words
             report_src_words += batch[0].data.ne(onmt.Constants.PAD).sum()
             if i % opt.log_interval == 0 and i > 0:
-                print("Epoch %2d, %5d/%5d; ppl: %6.2f; acc: %6.2f; %3.0f src tok/s; %3.0f tgt tok/s; %6.0f s elapsed" %
+                print("Epoch %2d, %5d/%5d; acc: %6.2f; ppl: %6.2f; %3.0f src tok/s; %3.0f tgt tok/s; %6.0f s elapsed" %
                       (epoch, i, len(trainData),
-                      math.exp(report_loss / report_tgt_words),
                       num_correct / num_words * 100,
+                      math.exp(report_loss / report_tgt_words),
                       report_src_words/(time.time()-start),
                       report_tgt_words/(time.time()-start),
                       time.time()-start_time))
@@ -240,7 +240,7 @@ def trainModel(model, trainData, validData, dataset, optim):
         valid_loss, valid_acc = eval(model, criterion, validData)
         valid_ppl = math.exp(min(valid_loss, 100))
         print('Validation perplexity: %g' % valid_ppl)
-        print('Validation accuracy: %g' % valid_acc)
+        print('Validation accuracy: %g' % (valid_acc*100))
 
         #  (3) maybe update the learning rate
         if opt.update_learning_rate:
@@ -255,7 +255,7 @@ def trainModel(model, trainData, validData, dataset, optim):
             'optim': optim,
         }
         torch.save(checkpoint,
-                   '%s_acc_%.2f_ppl_%.2f_e%d.pt' % (opt.save_model, valid_acc, valid_ppl, epoch))
+                   '%s_acc_%.2f_ppl_%.2f_e%d.pt' % (opt.save_model, 100*valid_acc, valid_ppl, epoch))
 
 def main():
 

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -186,8 +186,8 @@ def trainModel(model, trainData, validData, dataset, optim):
         # shuffle mini batch order
         batchOrder = torch.randperm(len(trainData))
 
-        total_loss, total_words, total_num_correct = 0
-        report_loss, report_tgt_words, report_src_words, report_num_correct = 0
+        total_loss, total_words, total_num_correct = 0, 0, 0
+        report_loss, report_tgt_words, report_src_words, report_num_correct = 0, 0, 0, 0
         start = time.time()
         for i in range(len(trainData)):
 
@@ -215,7 +215,7 @@ def trainModel(model, trainData, validData, dataset, optim):
             total_words += num_words
             if i % opt.log_interval == -1 % opt.log_interval:
                 print("Epoch %2d, %5d/%5d; acc: %6.2f; ppl: %6.2f; %3.0f src tok/s; %3.0f tgt tok/s; %6.0f s elapsed" %
-                      (epoch, i, len(trainData),
+                      (epoch, i+1, len(trainData),
                       report_num_correct / report_tgt_words * 100,
                       math.exp(report_loss / report_tgt_words),
                       report_src_words/(time.time()-start),

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -156,9 +156,6 @@ def eval(model, criterion, data):
 def trainModel(model, trainData, validData, dataset, optim):
     print(model)
     model.train()
-    if optim.last_ppl is None:
-        for p in model.parameters():
-            p.data.uniform_(-opt.param_init, opt.param_init)
 
     # define criterion of each GPU
     criterion = NMTCriterion(dataset['dicts']['tgt'].size())

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -186,9 +186,8 @@ def trainModel(model, trainData, validData, dataset, optim):
         # shuffle mini batch order
         batchOrder = torch.randperm(len(trainData))
 
-        total_loss, report_loss = 0, 0
-        total_words, report_tgt_words, report_src_words = 0, 0, 0
-        total_num_correct = 0
+        total_loss, total_words, total_num_correct = 0
+        report_loss, report_tgt_words, report_src_words, report_num_correct = 0
         start = time.time()
         for i in range(len(trainData)):
 
@@ -206,23 +205,24 @@ def trainModel(model, trainData, validData, dataset, optim):
             # update the parameters
             optim.step()
 
-            report_loss += loss
-            total_num_correct += num_correct
-            total_loss += loss
             num_words = targets.data.ne(onmt.Constants.PAD).sum()
-            total_words += num_words
+            report_loss += loss
+            report_num_correct += num_correct
             report_tgt_words += num_words
             report_src_words += batch[0].data.ne(onmt.Constants.PAD).sum()
+            total_loss += loss
+            total_num_correct += num_correct
+            total_words += num_words
             if i % opt.log_interval == -1 % opt.log_interval:
                 print("Epoch %2d, %5d/%5d; acc: %6.2f; ppl: %6.2f; %3.0f src tok/s; %3.0f tgt tok/s; %6.0f s elapsed" %
                       (epoch, i, len(trainData),
-                      num_correct / num_words * 100,
+                      report_num_correct / report_tgt_words * 100,
                       math.exp(report_loss / report_tgt_words),
                       report_src_words/(time.time()-start),
                       report_tgt_words/(time.time()-start),
                       time.time()-start_time))
 
-                report_loss = report_tgt_words = report_src_words = 0
+                report_loss = report_tgt_words = report_src_words = report_num_correct = 0
                 start = time.time()
 
         return total_loss / total_words, total_num_correct / total_words

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -229,7 +229,7 @@ def trainModel(model, trainData, validData, dataset, optim):
             'optim': optim,
         }
         torch.save(checkpoint,
-                   '%s_val%.2f_train%.2f_e%d.pt' % (opt.save_model, valid_ppl, train_ppl, epoch))
+                   '%s_val_%.2f_train_%.2f_e%d.pt' % (opt.save_model, valid_ppl, train_ppl, epoch))
 
 def main():
 

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -236,6 +236,9 @@ def main():
     print("Loading data from '%s'" % opt.data)
 
     dataset = torch.load(opt.data)
+    if opt.train_from:
+        checkpoint = torch.load(opt.train_from)
+        dataset['dicts'] = checkpoint['dicts']
 
     trainData = onmt.Dataset(dataset['train']['src'],
                              dataset['train']['tgt'], opt.batch_size, opt.gpus)

--- a/OpenNMT/train.py
+++ b/OpenNMT/train.py
@@ -183,7 +183,7 @@ def trainModel(model, trainData, validData, dataset, optim):
             outputs.backward(gradOutput)
 
             # update the parameters
-            grad_norm = optim.step()
+            optim.step()
 
             report_loss += loss
             total_loss += loss

--- a/OpenNMT/translate.py
+++ b/OpenNMT/translate.py
@@ -78,7 +78,7 @@ def main():
         predBatch, predScore, goldScore = translator.translate(srcBatch, tgtBatch)
 
         predScoreTotal += sum(score[0] for score in predScore)
-        predWordsTotal += sum(len(x) for x in predBatch)
+        predWordsTotal += sum(len(x[0]) for x in predBatch)
         if tgtF is not None:
             goldScoreTotal += sum(goldScore)
             goldWordsTotal += sum(len(x) for x in tgtBatch)

--- a/OpenNMT/translate.py
+++ b/OpenNMT/translate.py
@@ -99,7 +99,7 @@ def main():
                 if opt.n_best > 1:
                     print('\nBEST HYP:')
                     for n in range(opt.n_best):
-                        print("[%.4f] %s" % (predScore[b][n], " ".join(predBatch[b][0])))
+                        print("[%.4f] %s" % (predScore[b][n], " ".join(predBatch[b][n])))
 
                 print('')
 

--- a/OpenNMT/translate.py
+++ b/OpenNMT/translate.py
@@ -50,7 +50,8 @@ def reportScore(name, scoreTotal, wordsTotal):
 def main():
     opt = parser.parse_args()
     opt.cuda = opt.gpu > -1
-    torch.cuda.set_device(opt.gpu)
+    if opt.cuda:
+        torch.cuda.set_device(opt.gpu)
 
     translator = onmt.Translator(opt)
 

--- a/OpenNMT/translate.py
+++ b/OpenNMT/translate.py
@@ -88,12 +88,18 @@ def main():
             outF.write(" ".join(predBatch[b][0]) + '\n')
 
             if opt.verbose:
-                print('SENT %d: %s' % (count, " ".join(srcBatch[b])))
+                srcSent = ' '.join(srcBatch[b])
+                if translator.tgt_dict.lower:
+                    srcSent = srcSent.lower()
+                print('SENT %d: %s' % (count, srcSent))
                 print('PRED %d: %s' % (count, " ".join(predBatch[b][0])))
                 print("PRED SCORE: %.4f" % predScore[b][0])
 
                 if tgtF is not None:
-                    print('GOLD %d: %s ' % (count, " ".join(tgtBatch[b])))
+                    tgtSent = ' '.join(tgtBatch[b])
+                    if translator.tgt_dict.lower:
+                        tgtSent = tgtSent.lower()
+                    print('GOLD %d: %s ' % (count, tgtSent))
                     print("GOLD SCORE: %.4f" % goldScore[b])
 
                 if opt.n_best > 1:


### PR DESCRIPTION
Done:

- fixes bug in translate when user wishes to use cpu by passing -1 as device number

- removes re-initialization of checkpoint parameters

- replaces chunking with splitting

- removes unnecessary opt.cuda

- replace pre-ModuleList code with ModuleList

- converts to int when user wants to use the start_decay_at argument

-  fixes issue with decoder hidden state (https://github.com/pytorch/examples/issues/88)

- replaces from-scratch gradient clipping with nn.utils.clip_grad_norm

- adds additional logging for source and target tokens per second

- fixed: index was set to 0 in the translate.py code for printing the n best

- fixed: len was applied the batch (always giving batch size) rather than the top prediction for each batch when counting the total number of predicted words in translate.py

- added info on how one might go about prepping data for an MT task from scratch (Flickr30k) since demo data was already tokenized. 

- replace LSTMCell with a single-step single-layer LSTM (https://github.com/pytorch/examples/pull/80) [reverted to LSTMCell as pytorch overhead for calling cudnn makes the nn.LSTM version slower than the one based on LSTMCell]

- do not manually unroll encoder in onmt/Translator.py for bidirectional encoders. The manual unroll was broken for bidirectional encoders. The downside is that inference no longer masks off hidden states of bidirectional encoders for time steps corresponding to padding. My experiments show that this will affect BLEU scores if there is padding. For now, to avoid this issue, one can run with batch size 1 for models trained with -brnn. Once the code is updated with https://github.com/pytorch/pytorch/pull/873, this will no longer be an issue.

- "rewrite memoryEfficientLoss, so that it first replicates the generator onto all used GPUs (say n), and then uses these modules with parallel_apply to process the n batches from the splits on each GPU using parallel_apply" (https://github.com/pytorch/examples/pull/80) [Tried model parallelism for the generator and it provided no benefit over using data parallelism, so I ended up leaving the data parallelism]
