### PR TITLE
Command Line Interface backwards compatible fix for models.py

### DIFF
--- a/word_language_model/model.py
+++ b/word_language_model/model.py
@@ -12,14 +12,11 @@ class RNNModel(nn.Module):
             self.rnn = getattr(nn, rnn_type)(ninp, nhid, nlayers, bias=False)
         else:
             try:
-                nonlinearity = {
-                    'RNN_TANH': 'tanh', 'RNN_RELU': 'relu'}[rnn_type]
+                nonlinearity = {'RNN_TANH': 'tanh', 'RNN_RELU': 'relu'}[rnn_type]
             except KeyError:
-                raise ValueError(
-                    """An invalid option for `--model` was supplied,
-                    options are ['LSTM', 'GRU', 'RNN_TANH' or 'RNN_RELU']""")
-            self.rnn = nn.RNN(
-                ninp, nhid, nlayers, nonlinearity=nonlinearity, bias=False)
+                raise ValueError( """An invalid option for `--model` was supplied,
+                                 options are ['LSTM', 'GRU', 'RNN_TANH' or 'RNN_RELU']""")
+            self.rnn = nn.RNN(ninp, nhid, nlayers, nonlinearity=nonlinearity, bias=False)
         self.decoder = nn.Linear(nhid, ntoken)
 
         self.init_weights()

--- a/word_language_model/model.py
+++ b/word_language_model/model.py
@@ -8,7 +8,18 @@ class RNNModel(nn.Module):
     def __init__(self, rnn_type, ntoken, ninp, nhid, nlayers):
         super(RNNModel, self).__init__()
         self.encoder = nn.Embedding(ntoken, ninp)
-        self.rnn = getattr(nn, rnn_type)(ninp, nhid, nlayers, bias=False)
+        if rnn_type in ['LSTM', 'GRU']:
+            self.rnn = getattr(nn, rnn_type)(ninp, nhid, nlayers, bias=False)
+        else:
+            try:
+                nonlinearity = {
+                    'RNN_TANH': 'tanh', 'RNN_RELU': 'relu'}[rnn_type]
+            except KeyError:
+                raise ValueError(
+                    """An invalid option for `--model` was supplied,
+                    options are ['LSTM', 'GRU', 'RNN_TANH' or 'RNN_RELU']""")
+            self.rnn = nn.RNN(
+                ninp, nhid, nlayers, nonlinearity=nonlinearity, bias=False)
         self.decoder = nn.Linear(nhid, ntoken)
 
         self.init_weights()


### PR DESCRIPTION
To address https://github.com/pytorch/examples/issues/83

I did it in this way so that the command line interface to the program would not have to change (i.e: you could still pass `--model RNN_TANH` as described in the help for `model` in the argument parser), but if it is desirable to change that we can make the fix a little bit cleaner.