### PR TITLE
Change the calculation method of the batch number. 

### DIFF
--- a/OpenNMT/onmt/Dataset.py
+++ b/OpenNMT/onmt/Dataset.py
@@ -14,7 +14,7 @@ class Dataset(object):
         self.cuda = cuda
 
         self.batchSize = batchSize
-        self.numBatches = len(self.src) // batchSize
+        self.numBatches = (len(self.src) + batchSize - 1) // batchSize
 
     def _batchify(self, data, align_right=False):
         max_length = max(x.size(0) for x in data)


### PR DESCRIPTION
Hi, I have changed the calculation method for batch number, since it will crash when dataset is smaller than 64. Since if dataset number is smaller than 64, `self.numBatches` will be 0 and will lead to crash.