### PR TITLE
update attribution of weight tying in word_language_model

### DIFF
--- a/word_language_model/README.md
+++ b/word_language_model/README.md
@@ -53,6 +53,4 @@ python main.py --cuda --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40 --tie
 
 These perplexities are equal or better than
 [Recurrent Neural Network Regularization (Zaremba et al. 2014)](https://arxiv.org/pdf/1409.2329.pdf)
-and are similar to
-[Tying Word Vectors and Word Classifiers: A Loss Framework for Language Modeling (Inan et al. 2016)](https://arxiv.org/pdf/1611.01462.pdf),
-though Inan et al. have improved perplexities by using a form of recurrent dropout (variational dropout).
+and are similar to [Using the Output Embedding to Improve Language Models (Press & Wolf 2016](https://arxiv.org/abs/1608.05859) and [Tying Word Vectors and Word Classifiers: A Loss Framework for Language Modeling (Inan et al. 2016)](https://arxiv.org/pdf/1611.01462.pdf), though both of these papers have improved perplexities by using a form of recurrent dropout [(variational dropout)](http://papers.nips.cc/paper/6241-a-theoretically-grounded-application-of-dropout-in-recurrent-neural-networks).

--- a/word_language_model/model.py
+++ b/word_language_model/model.py
@@ -20,6 +20,9 @@ class RNNModel(nn.Module):
         self.decoder = nn.Linear(nhid, ntoken)
 
         # Optionally tie weights as in:
+        # "Using the Output Embedding to Improve Language Models" (Press & Wolf 2016)
+        # https://arxiv.org/abs/1608.05859
+        # and
         # "Tying Word Vectors and Word Classifiers: A Loss Framework for Language Modeling" (Inan et al. 2016)
         # https://arxiv.org/abs/1611.01462
         if tie_weights:


### PR DESCRIPTION
As written in both Inan et. al. (2016) and Press & Wolf (2016), weight tying in RNN language models was developed in parallel by both of these teams, and so I've updated the attribution in the code to include both. 

