### PR TITLE
Switch the model to evaluation mode before generation in the language model example

### DIFF
--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -46,6 +46,7 @@ if args.temperature < 1e-3:
 
 with open(args.checkpoint, 'rb') as f:
     model = torch.load(f)
+model.eval()
 
 if args.cuda:
     model.cuda()


### PR DESCRIPTION
The model in the word language model example uses dropout, so I add a line to call model.eval() before generation.