### PR TITLE
Remove rectifier before softmax

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -64,7 +64,7 @@ class Net(nn.Module):
         x = x.view(-1, 320)
         x = F.relu(self.fc1(x))
         x = F.dropout(x, training=self.training)
-        x = F.relu(self.fc2(x))
+        x = self.fc2(x)
         return F.log_softmax(x)
 
 model = Net()

--- a/mnist_hogwild/main.py
+++ b/mnist_hogwild/main.py
@@ -41,7 +41,7 @@ class Net(nn.Module):
         x = x.view(-1, 320)
         x = F.relu(self.fc1(x))
         x = F.dropout(x, training=self.training)
-        x = F.relu(self.fc2(x))
+        x = self.fc2(x)
         return F.log_softmax(x)
 
 if __name__ == '__main__':


### PR DESCRIPTION
As far as I am concerned, `softmax(relu(h_last))` is a very unusual thing to do. Removed the rectifier for convergence and didactic purposes as discussed [here](https://discuss.pytorch.org/t/relu-in-mnist-example/1190/2). 