### PR TITLE
Fix Python 3 issue with time_sequence_prediction

### DIFF
--- a/time_sequence_prediction/train.py
+++ b/time_sequence_prediction/train.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
     np.random.seed(0)
     torch.manual_seed(0)
     # load data and make training set
-    data = torch.load(open('traindata.pt'))
+    data = torch.load('traindata.pt')
     input = Variable(torch.from_numpy(data[3:, :-1]), requires_grad=False)
     target = Variable(torch.from_numpy(data[3:, 1:]), requires_grad=False)
     # build the model


### PR DESCRIPTION
open without 'rb' caused Python 3 to open this in text mode and fail