### PR TITLE
snli/model.py: can run using Python 2.*

### DIFF
--- a/snli/model.py
+++ b/snli/model.py
@@ -10,7 +10,7 @@ class Bottle(nn.Module):
             return super(Bottle, self).forward(input)
         size = input.size()[:2]
         out = super(Bottle, self).forward(input.view(size[0]*size[1], -1))
-        return out.view(*size, -1)
+        return out.view(size[0], size[1], -1)
 
 
 class Linear(Bottle, nn.Linear):


### PR DESCRIPTION
Python 2.* does not support ``out.view(*size, -1)''. Expand it to ``out.view(size[0], size[1], -1)''.

Traceback (most recent call last):
  File "train.py", line 9, in <module>
    from model import SNLIClassifier
  File "snli/model.py", line 13
    return out.view(*size, -1)
SyntaxError: only named arguments may follow *expression