### PR TITLE
Fix help message for no-cuda

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -20,7 +20,7 @@ parser.add_argument('--lr', type=float, default=0.01, metavar='LR',
 parser.add_argument('--momentum', type=float, default=0.5, metavar='M',
                     help='SGD momentum (default: 0.5)')
 parser.add_argument('--no-cuda', action='store_true', default=False,
-                    help='enables CUDA training')
+                    help='disables CUDA training')
 parser.add_argument('--seed', type=int, default=1, metavar='S',
                     help='random seed (default: 1)')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',


### PR DESCRIPTION
Change the help message for `--no-cuda`, explaining it *disables* CUDA, not *enables* it as currently written. The joy of boolean optional command line arguments :)