### PR TITLE
mnist_hogwild manual breaking of gradient sharing removed

### DIFF
--- a/mnist_hogwild/main.py
+++ b/mnist_hogwild/main.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
     torch.manual_seed(args.seed)
 
     model = Net()
-    model.share_memory()
+    model.share_memory() # gradients are allocated lazily, so they are not shared here
 
     processes = []
     for rank in range(args.num_processes):

--- a/mnist_hogwild/train.py
+++ b/mnist_hogwild/train.py
@@ -7,10 +7,6 @@ from torchvision import datasets, transforms
 
 def train(rank, args, model):
     torch.manual_seed(args.seed + rank)
-    for param in model.parameters():
-        # Break gradient sharing
-        if param.grad is not None:
-            param.grad.data = param.grad.data.clone()
 
     train_loader = torch.utils.data.DataLoader(
         datasets.MNIST('../data', train=True, download=True,


### PR DESCRIPTION
Since gradients are allocated lazily, they are instantiated in every process separately on the `loss.backward()` call. The removed lines in train.py are no longer needed.