### PR TITLE
Bugs In MNIST

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -99,12 +99,11 @@ def test():
         data, target = Variable(data, volatile=True), Variable(target)
         current_batch_size = data.data.size()[0]
         output = model(data)
-        # F.nll_loss is averaged among each batch
-        test_loss += F.nll_loss(output, target).data[0] * current_batch_size
+        test_loss += F.nll_loss(output, target).data[0] * current_batch_size # sum up batch loss
         pred = output.data.max(1)[1] # get the index of the max log-probability
         correct += pred.eq(target.data).cpu().sum()
 
-    test_loss = test_loss # sum of loss function
+    test_loss = test_loss # sum of loss function over all data points
     test_loss /= len(test_loader.dataset)
     print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
         test_loss, correct, len(test_loader.dataset),

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -97,9 +97,8 @@ def test():
         if args.cuda:
             data, target = data.cuda(), target.cuda()
         data, target = Variable(data, volatile=True), Variable(target)
-        current_batch_size = data.data.size()[0]
         output = model(data)
-        test_loss += F.nll_loss(output, target).data[0] * current_batch_size # sum up batch loss
+        test_loss += F.nll_loss(output, target, size_average=False).data[0] # sum up batch loss
         pred = output.data.max(1)[1] # get the index of the max log-probability
         correct += pred.eq(target.data).cpu().sum()
 

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -97,13 +97,15 @@ def test():
         if args.cuda:
             data, target = data.cuda(), target.cuda()
         data, target = Variable(data, volatile=True), Variable(target)
+        current_batch_size = data.data.size()[0]
         output = model(data)
-        test_loss += F.nll_loss(output, target).data[0]
+        # F.nll_loss is averaged among each batch
+        test_loss += F.nll_loss(output, target).data[0] * current_batch_size
         pred = output.data.max(1)[1] # get the index of the max log-probability
         correct += pred.eq(target.data).cpu().sum()
 
-    test_loss = test_loss
-    test_loss /= len(test_loader) # loss function already averages over batch size
+    test_loss = test_loss # sum of loss function
+    test_loss /= len(test_loader.dataset)
     print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
         test_loss, correct, len(test_loader.dataset),
         100. * correct / len(test_loader.dataset)))
@@ -111,4 +113,4 @@ def test():
 
 for epoch in range(1, args.epochs + 1):
     train(epoch)
-    test(epoch)
+    test()

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -89,7 +89,7 @@ def train(epoch):
                 epoch, batch_idx * len(data), len(train_loader.dataset),
                 100. * batch_idx / len(train_loader), loss.data[0]))
 
-def test(epoch):
+def test():
     model.eval()
     test_loss = 0
     correct = 0

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -103,7 +103,6 @@ def test():
         pred = output.data.max(1)[1] # get the index of the max log-probability
         correct += pred.eq(target.data).cpu().sum()
 
-    test_loss = test_loss # sum of loss function over all data points
     test_loss /= len(test_loader.dataset)
     print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
         test_loss, correct, len(test_loader.dataset),


### PR DESCRIPTION
Found one bug in MNIST.
1. Go to this line: [MNIST main script](https://github.com/pytorch/examples/blob/master/mnist/main.py#L106)
So this code assumes that we have same number of data points in each batch, which actually not the case. And more accurate way should be multiply NNL_loss of each batch by its batch-size, and get the sum over whole data set, then divide it by the data set size.
2. The parameter `epoch` in [`test()` function](https://github.com/pytorch/examples/blob/master/mnist/main.py#L92) is useless. So we may as well remove it.