### PR TITLE
reinforcement_learning fix reward threshold

### DIFF
--- a/reinforcement_learning/actor_critic.py
+++ b/reinforcement_learning/actor_critic.py
@@ -99,7 +99,7 @@ for i_episode in count(1):
     if i_episode % args.log_interval == 0:
         print('Episode {}\tLast length: {:5d}\tAverage length: {:.2f}'.format(
             i_episode, t, running_reward))
-    if running_reward > 200:
+    if running_reward > env.spec.reward_threshold:
         print("Solved! Running reward is now {} and "
               "the last episode runs to {} time steps!".format(running_reward, t))
         break

--- a/reinforcement_learning/reinforce.py
+++ b/reinforcement_learning/reinforce.py
@@ -89,7 +89,7 @@ for i_episode in count(1):
     if i_episode % args.log_interval == 0:
         print('Episode {}\tLast length: {:5d}\tAverage length: {:.2f}'.format(
             i_episode, t, running_reward))
-    if running_reward > 200:
+    if running_reward > env.spec.reward_threshold:
         print("Solved! Running reward is now {} and "
               "the last episode runs to {} time steps!".format(running_reward, t))
         break


### PR DESCRIPTION
Since the gym package has changed, maximum step number is 200 in the cartpole environment, so the mean reward was unable to reach 200, and both reinforce and actor_critics scripts were never ending.
This fix replace the hard coded 200 step by env.spec.reward_threshold.

In the future and to avoid such cases were an updated package broke things, maybe 
`pip freeze > requirements.txt`
would help by freezing the current (and therefore working) version of each package ?