### PR TITLE
Change test DataLoader to use the test batch size

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -46,7 +46,7 @@ test_loader = torch.utils.data.DataLoader(
                        transforms.ToTensor(),
                        transforms.Normalize((0.1307,), (0.3081,))
                    ])),
-    batch_size=args.batch_size, shuffle=True, **kwargs)
+    batch_size=args.test_batch_size, shuffle=True, **kwargs)
 
 
 class Net(nn.Module):


### PR DESCRIPTION
The batch size for the training set was erroneously used for instantiating the DataLoader class for the test set.