### PR TITLE
h rather than c should be fed into the next layer of LSTM

### DIFF
--- a/time_sequence_prediction/train.py
+++ b/time_sequence_prediction/train.py
@@ -23,12 +23,12 @@ class Sequence(nn.Module):
 
         for i, input_t in enumerate(input.chunk(input.size(1), dim=1)):
             h_t, c_t = self.lstm1(input_t, (h_t, c_t))
-            h_t2, c_t2 = self.lstm2(c_t, (h_t2, c_t2))
-            outputs += [c_t2]
+            h_t2, c_t2 = self.lstm2(h_t, (h_t2, c_t2))
+            outputs += [h_t2]
         for i in range(future):# if we should predict the future
-            h_t, c_t = self.lstm1(c_t2, (h_t, c_t))
-            h_t2, c_t2 = self.lstm2(c_t, (h_t2, c_t2))
-            outputs += [c_t2]
+            h_t, c_t = self.lstm1(h_t2, (h_t, c_t))
+            h_t2, c_t2 = self.lstm2(h_t, (h_t2, c_t2))
+            outputs += [h_t2]
         outputs = torch.stack(outputs, 1).squeeze(2)
         return outputs
 


### PR DESCRIPTION
The time series prediction example is somewhat misleading. In a multilayer LSTM, h (the hidden state or output) rather than c should be fed into the next layer or output as the prediction. For the sine wave, the network learns to predict either way, but I believe the example should be fixed to show the correct use.