### PR TITLE
[BUG] potential typo in default learning rate

### DIFF
--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -19,7 +19,7 @@ parser.add_argument('--nhid', type=int, default=200,
                     help='number of hidden units per layer')
 parser.add_argument('--nlayers', type=int, default=2,
                     help='number of layers')
-parser.add_argument('--lr', type=float, default=20,
+parser.add_argument('--lr', type=float, default=2,
                     help='initial learning rate')
 parser.add_argument('--clip', type=float, default=0.25,
                     help='gradient clipping')


### PR DESCRIPTION
Training any baseline model with default settings cause exploding loss or no learning at all. 

The default is set at 20. Setting it to something like 1 or 2 allows the models to learn.