### PR TITLE
fix reinforcement_learning example

### DIFF
--- a/reinforcement_learning/actor_critic.py
+++ b/reinforcement_learning/actor_critic.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 from torch.autograd import Variable
-from torch.distributions import Multinomial
+from torch.distributions import Categorical
 
 
 parser = argparse.ArgumentParser(description='PyTorch actor-critic example')
@@ -56,7 +56,7 @@ optimizer = optim.Adam(model.parameters(), lr=3e-2)
 def select_action(state):
     state = torch.from_numpy(state).float().unsqueeze(0)
     probs, state_value = model(Variable(state))
-    m = Multinomial(probs)
+    m = Categorical(probs)
     action = m.sample()
     model.saved_actions.append(SavedAction(m.log_prob(action), state_value))
     return action.data[0]

--- a/reinforcement_learning/reinforce.py
+++ b/reinforcement_learning/reinforce.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 from torch.autograd import Variable
-from torch.distributions import Multinomial
+from torch.distributions import Categorical
 
 
 parser = argparse.ArgumentParser(description='PyTorch REINFORCE example')
@@ -50,7 +50,7 @@ optimizer = optim.Adam(policy.parameters(), lr=1e-2)
 def select_action(state):
     state = torch.from_numpy(state).float().unsqueeze(0)
     probs = policy(Variable(state))
-    m = Multinomial(probs)
+    m = Categorical(probs)
     action = m.sample()
     policy.saved_log_probs.append(m.log_prob(action))
     return action.data[0]


### PR DESCRIPTION
`torch.distributions.Multinomial` doesn't exist in v0.3.0, but `torch.distributions.Categorical` does