### PR TITLE
Inception_v3 takes a different input size.

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -116,10 +116,14 @@ def main():
     normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                      std=[0.229, 0.224, 0.225])
 
+    model_input_size = 224
+    if args.arch == 'inception_v3':
+        model_input_size = 299
+
     train_dataset = datasets.ImageFolder(
         traindir,
         transforms.Compose([
-            transforms.RandomResizedCrop(224),
+            transforms.RandomResizedCrop(model_input_size),
             transforms.RandomHorizontalFlip(),
             transforms.ToTensor(),
             normalize,
@@ -136,8 +140,8 @@ def main():
 
     val_loader = torch.utils.data.DataLoader(
         datasets.ImageFolder(valdir, transforms.Compose([
-            transforms.Resize(256),
-            transforms.CenterCrop(224),
+            transforms.Resize(model_input_size),
+            transforms.CenterCrop(model_input_size),
             transforms.ToTensor(),
             normalize,
         ])),


### PR DESCRIPTION
Inception_v3 takes an input of 299\*299\*3 instead of 224\*224\*3. This needs to be changed, otherwise, it will complain "...output size is too small..." when running the inception_v3 model.