### PR TITLE
Error when running stylize image in fast-neural-style example

### DIFF
--- a/fast_neural_style/neural_style/transformer_net.py
+++ b/fast_neural_style/neural_style/transformer_net.py
@@ -87,7 +87,7 @@ class UpsampleConvLayer(torch.nn.Module):
         super(UpsampleConvLayer, self).__init__()
         self.upsample = upsample
         if upsample:
-            self.upsample_layer = torch.nn.UpsamplingNearest2d(scale_factor=upsample)
+            self.upsample_layer = torch.nn.Upsample(scale_factor=upsample)
         reflection_padding = kernel_size // 2
         self.reflection_pad = torch.nn.ReflectionPad2d(reflection_padding)
         self.conv2d = torch.nn.Conv2d(in_channels, out_channels, kernel_size, stride)


### PR DESCRIPTION
I get an error because torch.nn.UpsamplingNearest2d has been deprecated. I swapped it with torch.nn.Upsample and it works. See example below:

My version of pytorch
`python3 -c "import torch; print(torch.__version__)"`
0.3.0.post4

The error I get when using the deprecated function:

`python3 neural_style/neural_style.py eval --content-image ~/Downloads/arena.jpeg --model ~/Downloads/saved_models/mosaic.pth --output-image ~/Downloads/arena_mod.jpeg --cuda 0`
/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/torch/nn/modules/upsampling.py:133: UserWarning: nn.UpsamplingNearest2d is deprecated. Use nn.Upsample instead.
  warnings.warn("nn.UpsamplingNearest2d is deprecated. Use nn.Upsample instead.")
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/PIL/Image.py", line 1911, in save
    format = EXTENSION[ext]
KeyError: ''

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "neural_style/neural_style.py", line 226, in <module>
    main()
  File "neural_style/neural_style.py", line 222, in main
    stylize(args)
  File "neural_style/neural_style.py", line 157, in stylize
    utils.save_image(args.output_image, output_data)
  File "/Users/gballardin/Desktop/examples/fast_neural_style/neural_style/utils.py", line 19, in save_image
    img.save(filename)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/PIL/Image.py", line 1913, in save
    raise ValueError('unknown file extension: {}'.format(ext))
ValueError: unknown file extension:
