### PR TITLE
Fix UserWarning in two examples

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -65,7 +65,7 @@ class Net(nn.Module):
         x = F.relu(self.fc1(x))
         x = F.dropout(x, training=self.training)
         x = self.fc2(x)
-        return F.log_softmax(x)
+        return F.log_softmax(x, dim=1)
 
 model = Net()
 if args.cuda:

--- a/mnist_hogwild/main.py
+++ b/mnist_hogwild/main.py
@@ -42,7 +42,7 @@ class Net(nn.Module):
         x = F.relu(self.fc1(x))
         x = F.dropout(x, training=self.training)
         x = self.fc2(x)
-        return F.log_softmax(x)
+        return F.log_softmax(x, dim=1)
 
 if __name__ == '__main__':
     args = parser.parse_args()


### PR DESCRIPTION
Currently, running `python mnist/main.py` outputs the following:

````
mnist/main.py:68: UserWarning: Implicit dimension choice for log_softmax has been deprecated. Change the call to include dim=X as an argument.
  return F.log_softmax(x)
````

and `python mnist_hogwild/main.py` outputs
````
mnist_hogwild/main.py:45: UserWarning: Implicit dimension choice for log_softmax has been deprecated. Change the call to include dim=X as an argument.
  return F.log_softmax(x)
````

The output of these warnings to stderr can cause errors in systems that run `mnist/main.py` as a test script to check installation of PyTorch. To easily reproduce, run `python mnist/main.py > /dev/null`.

In both cases, `log_softmax` is always applied to a two-dimensional tensor with shape `batch_size x num_classes` and so the appropriate softmax dimension is `dim=1`. This PR fixes both warnings and has no other effect on performance.