### PR TITLE
Fix VAE losses (sum over everything)

### DIFF
--- a/vae/main.py
+++ b/vae/main.py
@@ -77,23 +77,20 @@ class VAE(nn.Module):
 model = VAE()
 if args.cuda:
     model.cuda()
+optimizer = optim.Adam(model.parameters(), lr=1e-3)
 
 
+# Reconstruction + KL divergence losses summed over all elements and batch
 def loss_function(recon_x, x, mu, logvar):
-    BCE = F.binary_cross_entropy(recon_x, x.view(-1, 784))
+    BCE = F.binary_cross_entropy(recon_x, x.view(-1, 784), size_average=False)
 
     # see Appendix B from VAE paper:
     # Kingma and Welling. Auto-Encoding Variational Bayes. ICLR, 2014
     # https://arxiv.org/abs/1312.6114
     # 0.5 * sum(1 + log(sigma^2) - mu^2 - sigma^2)
     KLD = -0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp())
-    # Normalise by same number of elements as in reconstruction
-    KLD /= args.batch_size * 784
 
     return BCE + KLD
-
-
-optimizer = optim.Adam(model.parameters(), lr=1e-3)
 
 
 def train(epoch):


### PR DESCRIPTION
Summation is consistent with notation in the paper. Results are still fine (test reconstructions and samples, noting that this VAE doesn't use conv layers and so results won't necessarily be as good):

![reconstruction_10](https://user-images.githubusercontent.com/991891/35716355-72d72940-07a6-11e8-8671-0f6db3fa8c04.png)
![sample_10](https://user-images.githubusercontent.com/991891/35716357-746f9c06-07a6-11e8-830a-55a3a2f546d3.png)

Closes https://github.com/pytorch/examples/issues/234 and https://github.com/pytorch/examples/issues/290.