### PR TITLE
Fix type check on hidden state

### DIFF
--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -103,8 +103,8 @@ criterion = nn.CrossEntropyLoss()
 
 def repackage_hidden(h):
     """Wraps hidden states in new Variables, to detach them from their history."""
-    if type(h) == Variable:
-        return Variable(h.data)
+    if isinstance(h, torch.Tensor):
+        return h.detach()
     else:
         return tuple(repackage_hidden(v) for v in h)
 


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/5785, the concrete type of all Tensor/Variable objects will be torch.Tensor. We should use `isinstance` instead of exact type checks.