### PR TITLE
Add --max-batches-per-epoch option to MNIST example

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 from torchvision import datasets, transforms
 from torch.autograd import Variable
+import sys
 
 # Training settings
 parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
@@ -15,6 +16,8 @@ parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
                     help='input batch size for testing (default: 1000)')
 parser.add_argument('--epochs', type=int, default=10, metavar='N',
                     help='number of epochs to train (default: 10)')
+parser.add_argument('--max-batches-per-epoch', type=int, default=sys.maxsize,
+                    help='maximum number of batches to use for each epoch (default: sys.maxsize)')
 parser.add_argument('--lr', type=float, default=0.01, metavar='LR',
                     help='learning rate (default: 0.01)')
 parser.add_argument('--momentum', type=float, default=0.5, metavar='M',
@@ -76,6 +79,7 @@ optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
 
 def train(epoch):
     model.train()
+    num_batches = 0
     for batch_idx, (data, target) in enumerate(train_loader):
         if args.cuda:
             data, target = data.cuda(), target.cuda()
@@ -90,6 +94,9 @@ def train(epoch):
                 print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
                     epoch, batch_idx * len(data), len(train_loader.dataset),
                     100. * batch_idx / len(train_loader), float(loss)))
+        num_batches += 1
+        if num_batches > args.max_batches_per_epoch:
+            break
 
 def test():
     model.eval()


### PR DESCRIPTION
The whole MNIST dataset takes ~90s to train on the new bare metal CPU perf machines. Adding `--max-batches-per-epoch` so that we can have less batches per epoch and get the perf result faster.

This will only change the code in the `perftests` branch.