### PR TITLE
Fix clip_grad_norm use for word_language_model example

### DIFF
--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -160,7 +160,7 @@ def train():
         loss.backward()
 
         # `clip_grad_norm` helps prevent the exploding gradient problem in RNNs / LSTMs.
-        torch.nn.utils.clip_grad_norm(model.parameters(), args.clip)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip)
         for p in model.parameters():
             p.data.add_(-lr, p.grad.data)
 


### PR DESCRIPTION
This fixes the test failure in https://ci.pytorch.org/jenkins/job/pytorch-builds/job/short-perf-test-gpu/2345/console.