### PR TITLE
[imagenet example]use ```lr_scheduler``` instead of ```adjust_learning_rate```

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -14,6 +14,7 @@ import torch.utils.data.distributed
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 import torchvision.models as models
+from torch.optim.lr_scheduler import StepLR
 
 model_names = sorted(name for name in models.__dict__
     if name.islower() and not name.startswith("__")
@@ -93,6 +94,8 @@ def main():
     optimizer = torch.optim.SGD(model.parameters(), args.lr,
                                 momentum=args.momentum,
                                 weight_decay=args.weight_decay)
+    # Sets the learning rate to the initial LR decayed by 10 every 30 epochs
+    scheduler = StepLR(optimizer, step_size=30, gamma=0.1, last_epoch=args.start_epoch)
 
     # optionally resume from a checkpoint
     if args.resume:
@@ -149,9 +152,9 @@ def main():
         return
 
     for epoch in range(args.start_epoch, args.epochs):
+        scheduler.step()
         if args.distributed:
             train_sampler.set_epoch(epoch)
-        adjust_learning_rate(optimizer, epoch)
 
         # train for one epoch
         train(train_loader, model, criterion, optimizer, epoch)
@@ -283,14 +286,6 @@ class AverageMeter(object):
         self.sum += val * n
         self.count += n
         self.avg = self.sum / self.count
-
-
-def adjust_learning_rate(optimizer, epoch):
-    """Sets the learning rate to the initial LR decayed by 10 every 30 epochs"""
-    lr = args.lr * (0.1 ** (epoch // 30))
-    for param_group in optimizer.param_groups:
-        param_group['lr'] = lr
-
 
 def accuracy(output, target, topk=(1,)):
     """Computes the precision@k for the specified values of k"""


### PR DESCRIPTION
PyTorch already have this function ```lr_scheduler``` to modify the learning rate,  so why we still use user-customized function ```adjust_learning_rate```?