### PR TITLE
fix fast_neural_style --export_onnx

### DIFF
--- a/fast_neural_style/neural_style/neural_style.py
+++ b/fast_neural_style/neural_style/neural_style.py
@@ -144,7 +144,7 @@ def stylize(args):
             style_model.to(device)
             if args.export_onnx:
                 assert args.export_onnx.endswith(".onnx"), "Export model file should end with .onnx"
-                output = torch.onnx._export(style_model, content_image, args.export_onnx)
+                output = torch.onnx._export(style_model, content_image, args.export_onnx).cpu()
             else:
                 output = style_model(content_image).cpu()
     utils.save_image(args.output_image, output[0])


### PR DESCRIPTION
Fix the following error when --export_onnx is enabled for fast_neural_style:

`$ python neural_style/neural_style.py eval --model saved_models/rain_princess.pth --export_onnx saved_models/rain_princess.onnx --content-image images/content-images/img.jpg --output-image images/output-images/img.jpg --cuda 1`

> Traceback (most recent call last):
  File "neural_style/neural_style.py", line 240, in <module>
    main()
  File "neural_style/neural_style.py", line 236, in main
    stylize(args)
  File "neural_style/neural_style.py", line 150, in stylize
    utils.save_image(args.output_image, output[0])
  File "/fast_neural_style/neural_style/utils.py", line 15, in save_image
    img = data.clone().clamp(0, 255).numpy()
TypeError: can't convert CUDA tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
