### PR TITLE
Change incorrect comment on accuracy metric

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -319,7 +319,7 @@ def adjust_learning_rate(optimizer, epoch):
 
 
 def accuracy(output, target, topk=(1,)):
-    """Computes the precision@k for the specified values of k"""
+    """Computes the recall@k for the specified values of k"""
     with torch.no_grad():
         maxk = max(topk)
         batch_size = target.size(0)


### PR DESCRIPTION
The way accuracy is implemented is computing recall@k not precision@k as stated. Note that this change is only arguing for consistency between code and comment, but is not making an assessment on the correctness of computing recall vs. precision.