### PR TITLE
Fix bug in reparameterize() in VAE example

### DIFF
--- a/vae/main.py
+++ b/vae/main.py
@@ -51,12 +51,9 @@ class VAE(nn.Module):
         return self.fc21(h1), self.fc22(h1)
 
     def reparameterize(self, mu, logvar):
-        if self.training:
-            std = torch.exp(0.5*logvar)
-            eps = torch.randn_like(std)
-            return eps.mul(std).add_(mu)
-        else:
-            return mu
+        std = torch.exp(0.5*logvar)
+        eps = torch.randn_like(std)
+        return eps.mul(std).add_(mu)
 
     def decode(self, z):
         h3 = F.relu(self.fc3(z))


### PR DESCRIPTION
The reparameterize() function should not be deterministic for validation/test mode. It should be the same as in training mode, otherwise what is computed is not the ELBO (i.e. the correct loss) but something else. This change will slightly change the test set error.