### PR TITLE
Use torchtext 0.3.1

### DIFF
--- a/snli/train.py
+++ b/snli/train.py
@@ -58,7 +58,6 @@ opt = O.Adam(model.parameters(), lr=args.lr)
 iterations = 0
 start = time.time()
 best_dev_acc = -1
-train_iter.repeat = False
 header = '  Time Epoch Iteration Progress    (%Epoch)   Loss   Dev/Loss     Accuracy  Dev/Accuracy'
 dev_log_template = ' '.join('{:>6.0f},{:>5.0f},{:>9.0f},{:>5.0f}/{:<5.0f} {:>7.0f}%,{:>8.6f},{:8.6f},{:12.4f},{:12.4f}'.split(','))
 log_template =     ' '.join('{:>6.0f},{:>5.0f},{:>9.0f},{:>5.0f}/{:<5.0f} {:>7.0f}%,{:>8.6f},{},{:12.4f},{}'.split(','))
@@ -138,5 +137,3 @@ for epoch in range(args.epochs):
             print(log_template.format(time.time()-start,
                 epoch, iterations, 1+batch_idx, len(train_iter),
                 100. * (1+batch_idx) / len(train_iter), loss.item(), ' '*8, n_correct/n_total*100, ' '*12))
-
-


### PR DESCRIPTION
The default value of `repeat` of `iterator` class is `False` in [the current stable version of torchtext](https://github.com/pytorch/text/releases/tag/0.3.1).
So [this line](https://github.com/pytorch/examples/blob/master/snli/train.py#L61) is not necessary now.
