### PR TITLE
Bug fix in the calculation of the validation loss

### DIFF
--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -138,7 +138,7 @@ def evaluate(data_source):
             output_flat = output.view(-1, ntokens)
             total_loss += len(data) * criterion(output_flat, targets).item()
             hidden = repackage_hidden(hidden)
-    return total_loss / len(data_source)
+    return total_loss / (len(data_source) - 1)
 
 
 def train():


### PR DESCRIPTION
The last row of tokens in data_source in never used as input data in the last batch. Those tokens are always only used as targets and thus the total_loss variable shouldn't be divided by len(data_source) but len(data_source) - 1 instead.