### PR TITLE
[Distributed] Multiprocessing Distributed Training for ImageNet Example

### DIFF
--- a/imagenet/README.md
+++ b/imagenet/README.md
@@ -23,12 +23,36 @@ The default learning rate schedule starts at 0.1 and decays by a factor of 10 ev
 python main.py -a alexnet --lr 0.01 [imagenet-folder with train and val folders]
 ```
 
+## Multi-processing Distributed Data Parallel Training
+
+### Single node, multiple GPUs:
+
+```bash
+python main.py -a resnet50 --lr 0.01 --dist-url 'tcp://127.0.0.1:FREEPORT' --multiprocessing-distributed [imagenet-folder with train and val folders]
+```
+
+### Multiple nodes:
+
+Node 0:
+```bash
+python main.py -a resnet50 --lr 0.01 --dist-url 'tcp://IP_OF_NODE0:FREEPORT' --multiprocessing-distributed --world-size 2 --rank 0 [imagenet-folder with train and val folders]
+```
+
+Node 1:
+```bash
+python main.py -a resnet50 --lr 0.01 --dist-url 'tcp://IP_OF_NODE0:FREEPORT' --multiprocessing-distributed --world-size 2 --rank 1 [imagenet-folder with train and val folders]
+```
+
 ## Usage
 
 ```
 usage: main.py [-h] [--arch ARCH] [-j N] [--epochs N] [--start-epoch N] [-b N]
                [--lr LR] [--momentum M] [--weight-decay W] [--print-freq N]
-               [--resume PATH] [-e] [--pretrained]
+               [--resume PATH] [-e] [--pretrained] [--world-size WORLD_SIZE]
+               [--rank RANK] [--dist-url DIST_URL]
+               [--dist-backend DIST_BACKEND] [--seed SEED] [--gpu GPU]
+               [--multiprocessing-distributed] [--benchmark]
+               [--benchmark-iter BENCHMARK_ITER]
                DIR
 
 PyTorch ImageNet Training
@@ -38,14 +62,18 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  --arch ARCH, -a ARCH  model architecture: alexnet | resnet | resnet101 |
-                        resnet152 | resnet18 | resnet34 | resnet50 | vgg |
-                        vgg11 | vgg11_bn | vgg13 | vgg13_bn | vgg16 | vgg16_bn
-                        | vgg19 | vgg19_bn (default: resnet18)
+  --arch ARCH, -a ARCH  model architecture: alexnet | densenet121 |
+                        densenet161 | densenet169 | densenet201 | inception_v3
+                        | resnet101 | resnet152 | resnet18 | resnet34 |
+                        resnet50 | squeezenet1_0 | squeezenet1_1 | vgg11 |
+                        vgg11_bn | vgg13 | vgg13_bn | vgg16 | vgg16_bn | vgg19
+                        | vgg19_bn (default: resnet18)
   -j N, --workers N     number of data loading workers (default: 4)
   --epochs N            number of total epochs to run
   --start-epoch N       manual epoch number (useful on restarts)
-  -b N, --batch-size N  mini-batch size (default: 256)
+  -b N, --batch-size N  mini-batch size (default: 256), this is the total
+                        batch size of all GPUs on the current node when using
+                        Data Parallel or Distributed Data Parallel
   --lr LR, --learning-rate LR
                         initial learning rate
   --momentum M          momentum
@@ -55,4 +83,20 @@ optional arguments:
   --resume PATH         path to latest checkpoint (default: none)
   -e, --evaluate        evaluate model on validation set
   --pretrained          use pre-trained model
+  --world-size WORLD_SIZE
+                        number of nodes for distributed training
+  --rank RANK           node rank for distributed training
+  --dist-url DIST_URL   url used to set up distributed training
+  --dist-backend DIST_BACKEND
+                        distributed backend
+  --seed SEED           seed for initializing training.
+  --gpu GPU             GPU id to use.
+  --multiprocessing-distributed
+                        Use multi-processing distributed training to launch N
+                        processes per node, which has N GPUs. This is the
+                        fastest way to use PyTorch for either single node or
+                        multi node data parallel training
+  --benchmark           Benchmark mode, will use synthetic image data
+  --benchmark-iter BENCHMARK_ITER
+                        Number of iterations to benchmark
 ```

--- a/imagenet/README.md
+++ b/imagenet/README.md
@@ -25,22 +25,24 @@ python main.py -a alexnet --lr 0.01 [imagenet-folder with train and val folders]
 
 ## Multi-processing Distributed Data Parallel Training
 
+You should always use the NCCL backend for multi-processing distributed training since it currently provides the best distributed training performance.
+
 ### Single node, multiple GPUs:
 
 ```bash
-python main.py -a resnet50 --lr 0.01 --dist-url 'tcp://127.0.0.1:FREEPORT' --multiprocessing-distributed [imagenet-folder with train and val folders]
+python main.py -a resnet50 --lr 0.01 --dist-url 'tcp://127.0.0.1:FREEPORT' --dist-backend 'nccl' --multiprocessing-distributed [imagenet-folder with train and val folders]
 ```
 
 ### Multiple nodes:
 
 Node 0:
 ```bash
-python main.py -a resnet50 --lr 0.01 --dist-url 'tcp://IP_OF_NODE0:FREEPORT' --multiprocessing-distributed --world-size 2 --rank 0 [imagenet-folder with train and val folders]
+python main.py -a resnet50 --lr 0.01 --dist-url 'tcp://IP_OF_NODE0:FREEPORT' --dist-backend 'nccl' --multiprocessing-distributed --world-size 2 --rank 0 [imagenet-folder with train and val folders]
 ```
 
 Node 1:
 ```bash
-python main.py -a resnet50 --lr 0.01 --dist-url 'tcp://IP_OF_NODE0:FREEPORT' --multiprocessing-distributed --world-size 2 --rank 1 [imagenet-folder with train and val folders]
+python main.py -a resnet50 --lr 0.01 --dist-url 'tcp://IP_OF_NODE0:FREEPORT' --dist-backend 'nccl' --multiprocessing-distributed --world-size 2 --rank 1 [imagenet-folder with train and val folders]
 ```
 
 ## Usage
@@ -51,8 +53,7 @@ usage: main.py [-h] [--arch ARCH] [-j N] [--epochs N] [--start-epoch N] [-b N]
                [--resume PATH] [-e] [--pretrained] [--world-size WORLD_SIZE]
                [--rank RANK] [--dist-url DIST_URL]
                [--dist-backend DIST_BACKEND] [--seed SEED] [--gpu GPU]
-               [--multiprocessing-distributed] [--benchmark]
-               [--benchmark-iter BENCHMARK_ITER]
+               [--multiprocessing-distributed]
                DIR
 
 PyTorch ImageNet Training
@@ -63,8 +64,8 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --arch ARCH, -a ARCH  model architecture: alexnet | densenet121 |
-                        densenet161 | densenet169 | densenet201 | inception_v3
-                        | resnet101 | resnet152 | resnet18 | resnet34 |
+                        densenet161 | densenet169 | densenet201 |
+                        resnet101 | resnet152 | resnet18 | resnet34 |
                         resnet50 | squeezenet1_0 | squeezenet1_1 | vgg11 |
                         vgg11_bn | vgg13 | vgg13_bn | vgg16 | vgg16_bn | vgg19
                         | vgg19_bn (default: resnet18)
@@ -96,7 +97,4 @@ optional arguments:
                         processes per node, which has N GPUs. This is the
                         fastest way to use PyTorch for either single node or
                         multi node data parallel training
-  --benchmark           Benchmark mode, will use synthetic image data
-  --benchmark-iter BENCHMARK_ITER
-                        Number of iterations to benchmark
 ```

--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -4,6 +4,7 @@ import random
 import shutil
 import time
 import warnings
+import sys
 
 import torch
 import torch.nn as nn
@@ -11,6 +12,7 @@ import torch.nn.parallel
 import torch.backends.cudnn as cudnn
 import torch.distributed as dist
 import torch.optim
+import torch.multiprocessing as mp
 import torch.utils.data
 import torch.utils.data.distributed
 import torchvision.transforms as transforms
@@ -36,7 +38,10 @@ parser.add_argument('--epochs', default=90, type=int, metavar='N',
 parser.add_argument('--start-epoch', default=0, type=int, metavar='N',
                     help='manual epoch number (useful on restarts)')
 parser.add_argument('-b', '--batch-size', default=256, type=int,
-                    metavar='N', help='mini-batch size (default: 256)')
+                    metavar='N',
+                    help='mini-batch size (default: 256), this is the total '
+                         'batch size of all GPUs on the current node when '
+                         'using Data Parallel or Distributed Data Parallel')
 parser.add_argument('--lr', '--learning-rate', default=0.1, type=float,
                     metavar='LR', help='initial learning rate')
 parser.add_argument('--momentum', default=0.9, type=float, metavar='M',
@@ -52,23 +57,37 @@ parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
 parser.add_argument('--pretrained', dest='pretrained', action='store_true',
                     help='use pre-trained model')
 parser.add_argument('--world-size', default=1, type=int,
-                    help='number of distributed processes')
+                    help='number of nodes for distributed training')
+parser.add_argument('--rank', default=0, type=int,
+                    help='node rank for distributed training')
 parser.add_argument('--dist-url', default='tcp://224.66.41.62:23456', type=str,
                     help='url used to set up distributed training')
-parser.add_argument('--dist-backend', default='gloo', type=str,
+parser.add_argument('--dist-backend', default='nccl', type=str,
                     help='distributed backend')
 parser.add_argument('--seed', default=None, type=int,
                     help='seed for initializing training. ')
 parser.add_argument('--gpu', default=None, type=int,
                     help='GPU id to use.')
+parser.add_argument('--multiprocessing-distributed', action='store_true',
+                    help='Use multi-processing distributed training to launch '
+                         'N processes per node, which has N GPUs. This is the '
+                         'fastest way to use PyTorch for either single node or '
+                         'multi node data parallel training')
+parser.add_argument('--benchmark', action='store_true',
+                    help='Benchmark mode, will use synthetic image data')
+parser.add_argument('--benchmark-iter', default=100, type=int,
+                    help='Number of iterations to benchmark')
 
 best_acc1 = 0
 
 
 def main():
-    global args, best_acc1
     args = parser.parse_args()
 
+    if args.benchmark:
+        if args.benchmark_iter < 20:
+            raise RuntimeError("Requires a minimum of 20 iterations to "
+                               "benchmark")
     if args.seed is not None:
         random.seed(args.seed)
         torch.manual_seed(args.seed)
@@ -83,12 +102,63 @@ def main():
         warnings.warn('You have chosen a specific GPU. This will completely '
                       'disable data parallelism.')
 
-    args.distributed = args.world_size > 1
+    args.distributed = args.world_size > 1 or args.multiprocessing_distributed
+
+    ngpus_per_node = torch.cuda.device_count()
+    if args.multiprocessing_distributed:
+        # python version check
+        if not ((sys.version_info[0] == 3 and sys.version_info[1] >= 4) or
+                sys.version_info[0] > 3):
+            raise RuntimeError("Requires python 3.4 or higher to use "
+                               "torch.multiprocessing.spawn helper to launch "
+                               "multiple processes for distributed training. "
+                               "If you have a lower version of Python, use "
+                               "torch.distributed.launch instead.")
+        # Since we have ngpus_per_node processes per node, the total world_size
+        # needs to be adjusted accordingly
+        args.world_size = ngpus_per_node * args.world_size
+        # Use torch.multiprocessing.spawn to launch distributed processes: the
+        # main_worker process function
+        #
+        # Note: mp.spawn requires the called function (main_worker)'s first
+        # argument to be the local rank or the local GPU id that the main_worker
+        # will be operating on, and mp.spawn will set this up automatically.
+        # Therefore, the first argument of main_worker function does not need
+        # to be set in mp.spawn and it is your responsibility to ensure that
+        # the first argument of main_worker function (or any function passed to
+        # mp.spawn) is the gpu (device ID) the function should operate on.
+        mp.spawn(
+            main_worker,
+            nprocs=ngpus_per_node,
+            args=(ngpus_per_node, args)
+        )
+    else:
+        # Simply call main_worker function
+        main_worker(args.gpu, ngpus_per_node, args)
+
+
+def main_worker(gpu, ngpus_per_node, args):
+    global best_acc1
+    args.gpu = gpu
+
+    if args.gpu is not None:
+        print("Use GPU: {} for training".format(args.gpu))
 
     if args.distributed:
-        dist.init_process_group(backend=args.dist_backend, init_method=args.dist_url,
-                                world_size=args.world_size)
-
+        if args.multiprocessing_distributed:
+            # For multiprocessing distributed training, rank needs to be the i
+            # global rank among all the processes
+            args.rank = args.rank * ngpus_per_node + gpu
+            if args.dist_backend != 'nccl':
+                args.dist_backend = 'nccl'
+                warnings.warn('NCCL backend is the highly recommended backend '
+                              'for multiprocessing distributed training. Will '
+                              'automatically switch to using NCCL backend and '
+                              'continue the training.')
+        dist.init_process_group(backend=args.dist_backend,
+                                init_method=args.dist_url,
+                                world_size=args.world_size,
+                                rank=args.rank)
     # create model
     if args.pretrained:
         print("=> using pre-trained model '{}'".format(args.arch))
@@ -97,12 +167,32 @@ def main():
         print("=> creating model '{}'".format(args.arch))
         model = models.__dict__[args.arch]()
 
-    if args.gpu is not None:
+    if args.distributed:
+        # For multiprocessing distributed, DistributedDataParallel constructor
+        # should always set the single device scope, otherwise,
+        # DistributedDataParallel will use all available devices.
+        if args.gpu is not None:
+            torch.cuda.set_device(args.gpu)
+            model.cuda(args.gpu)
+            # When using a single GPU per process and per
+            # DistributedDataParallel, we need to divide the batch size
+            # ourselves based on the total number of GPUs we have
+            args.batch_size = int(args.batch_size / ngpus_per_node)
+            model = torch.nn.parallel.DistributedDataParallel(
+                model,
+                device_ids=[args.gpu],
+                output_device=None)
+        else:
+            model.cuda()
+            # DistributedDataParallel will divide and allocate batch_size to all
+            # available GPUs if device_ids are not not set
+            model = torch.nn.parallel.DistributedDataParallel(model)
+    elif args.gpu is not None:
+        torch.cuda.set_device(args.gpu)
         model = model.cuda(args.gpu)
-    elif args.distributed:
-        model.cuda()
-        model = torch.nn.parallel.DistributedDataParallel(model)
     else:
+        # DataParallel will divide and allocate batch_size to all
+        # available GPUs
         if args.arch.startswith('alexnet') or args.arch.startswith('vgg'):
             model.features = torch.nn.DataParallel(model.features)
             model.cuda()
@@ -115,6 +205,10 @@ def main():
     optimizer = torch.optim.SGD(model.parameters(), args.lr,
                                 momentum=args.momentum,
                                 weight_decay=args.weight_decay)
+
+    if args.benchmark:
+        train_bench(model, criterion, optimizer, args)
+        return
 
     # optionally resume from a checkpoint
     if args.resume:
@@ -173,13 +267,13 @@ def main():
     for epoch in range(args.start_epoch, args.epochs):
         if args.distributed:
             train_sampler.set_epoch(epoch)
-        adjust_learning_rate(optimizer, epoch)
+        adjust_learning_rate(optimizer, epoch, args)
 
         # train for one epoch
-        train(train_loader, model, criterion, optimizer, epoch)
+        train(train_loader, model, criterion, optimizer, epoch, args)
 
         # evaluate on validation set
-        acc1 = validate(val_loader, model, criterion)
+        acc1 = validate(val_loader, model, criterion, args)
 
         # remember best acc@1 and save checkpoint
         is_best = acc1 > best_acc1
@@ -193,7 +287,7 @@ def main():
         }, is_best)
 
 
-def train(train_loader, model, criterion, optimizer, epoch):
+def train(train_loader, model, criterion, optimizer, epoch, args):
     batch_time = AverageMeter()
     data_time = AverageMeter()
     losses = AverageMeter()
@@ -242,7 +336,46 @@ def train(train_loader, model, criterion, optimizer, epoch):
                    data_time=data_time, loss=losses, top1=top1, top5=top5))
 
 
-def validate(val_loader, model, criterion):
+def train_bench(model, criterion, optimizer, args):
+    batch_time = AverageMeter()
+
+    # switch to train mode
+    model.train()
+
+    # synthetic image data
+    input = torch.cuda.FloatTensor(args.batch_size, 3, 224, 224).fill_(1)
+    target = torch.cuda.LongTensor(args.batch_size).fill_(1)
+
+    end = time.time()
+    for i in range(args.benchmark_iter):
+        # measure data loading time
+
+        input_var = torch.autograd.Variable(input)
+        target_var = torch.autograd.Variable(target)
+
+        # compute output
+        output = model(input_var)
+        loss = criterion(output, target_var)
+
+        # compute gradient and do SGD step
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+        # measure elapsed time
+        if i >= 10 and i != args.benchmark_iter - 1 :
+            batch_time.update(time.time() - end)
+        end = time.time()
+
+        print('[{0}][{1}/{2}]\t'
+              'Time {batch_time.val:.3f} ({batch_time.avg:.3f})'.
+               format("Benchmark",
+                      i,
+                      args.benchmark_iter,
+                      batch_time=batch_time))
+
+
+def validate(val_loader, model, criterion, args):
     batch_time = AverageMeter()
     losses = AverageMeter()
     top1 = AverageMeter()
@@ -311,7 +444,7 @@ class AverageMeter(object):
         self.avg = self.sum / self.count
 
 
-def adjust_learning_rate(optimizer, epoch):
+def adjust_learning_rate(optimizer, epoch, args):
     """Sets the learning rate to the initial LR decayed by 10 every 30 epochs"""
     lr = args.lr * (0.1 ** (epoch // 30))
     for param_group in optimizer.param_groups:


### PR DESCRIPTION
Added multiprocessing mode for distributed training. This will use `torch.multiprocessing.spawn` for both single node and multi-node training.

Tested by verifying the following works:

(1) Single Node Single GPU
(2) Single Node Multi GPU
(3) multiprocessing single node Multi GPU distributed
(4) non-multiprocessing single node multi GPU distributed