### PR TITLE
Fix broken args order

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -43,11 +43,12 @@ parser.add_argument('-b', '--batch-size', default=256, type=int,
                          'batch size of all GPUs on the current node when '
                          'using Data Parallel or Distributed Data Parallel')
 parser.add_argument('--lr', '--learning-rate', default=0.1, type=float,
-                    metavar='LR', help='initial learning rate')
+                    metavar='LR', help='initial learning rate', dest='lr')
 parser.add_argument('--momentum', default=0.9, type=float, metavar='M',
                     help='momentum')
 parser.add_argument('--wd', '--weight-decay', default=1e-4, type=float,
-                    metavar='W', help='weight decay (default: 1e-4)')
+                    metavar='W', help='weight decay (default: 1e-4)',
+                    dest='weight_decay')
 parser.add_argument('-p', '--print-freq', default=10, type=int,
                     metavar='N', help='print frequency (default: 10)')
 parser.add_argument('--resume', default='', type=str, metavar='PATH',


### PR DESCRIPTION
For multiple long options, python takes the first as attribute name by default. The latest commit swapped the order of options that causes the script an error (e.g., AttributeError: 'Namespace' object has no attribute 'weight_decay'). Added dest option to explicitly specify the valid attribute name.