### PR TITLE
Fix a typo in the `actor_critic` example

### DIFF
--- a/reinforcement_learning/actor_critic.py
+++ b/reinforcement_learning/actor_critic.py
@@ -15,7 +15,7 @@ parser = argparse.ArgumentParser(description='PyTorch actor-critic example')
 parser.add_argument('--gamma', type=float, default=0.99, metavar='G',
                     help='discount factor (default: 0.99)')
 parser.add_argument('--seed', type=int, default=543, metavar='N',
-                    help='random seed (default: 1)')
+                    help='random seed (default: 543)')
 parser.add_argument('--render', action='store_true',
                     help='render the environment')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',


### PR DESCRIPTION
Original:
```
parser.add_argument('--seed', type=int, default=543, metavar='N',
                    help='random seed (default: 1)')
```
Fixed:
```
parser.add_argument('--seed', type=int, default=543, metavar='N',
                    help='random seed (default: 543)')
```