### PR TITLE
Add missing world size argument

### DIFF
--- a/imagenet/README.md
+++ b/imagenet/README.md
@@ -30,7 +30,7 @@ You should always use the NCCL backend for multi-processing distributed training
 ### Single node, multiple GPUs:
 
 ```bash
-python main.py -a resnet50 --lr 0.01 --dist-url 'tcp://127.0.0.1:FREEPORT' --dist-backend 'nccl' --multiprocessing-distributed [imagenet-folder with train and val folders]
+python main.py -a resnet50 --lr 0.01 --dist-url 'tcp://127.0.0.1:FREEPORT' --dist-backend 'nccl' --multiprocessing-distributed --world-size 1 [imagenet-folder with train and val folders]
 ```
 
 ### Multiple nodes:


### PR DESCRIPTION
15e27719d75e35358555a27215665c797999740f makes the command of single node fail with

> RuntimeError: NCCL error in: /pytorch/torch/lib/c10d/../c10d/NCCLUtils.hpp:39, invalid argument