### PR TITLE
Divide args.workers by ngpus_per_node

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -148,6 +148,7 @@ def main_worker(gpu, ngpus_per_node, args):
             # DistributedDataParallel, we need to divide the batch size
             # ourselves based on the total number of GPUs we have
             args.batch_size = int(args.batch_size / ngpus_per_node)
+            args.workers = int(args.workers / ngpus_per_node)
             model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[args.gpu])
         else:
             model.cuda()


### PR DESCRIPTION
Like `batch_size`, `workers` should be divided by `ngpus_per_node` too