### PR TITLE
Remove deprecated & unused Variable()

### DIFF
--- a/regression/main.py
+++ b/regression/main.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 from itertools import count
 
 import torch
-import torch.autograd
 import torch.nn.functional as F
 
 POLY_DEGREE = 4

--- a/super_resolution/super_resolve.py
+++ b/super_resolution/super_resolve.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import argparse
 import torch
-from torch.autograd import Variable
 from PIL import Image
 from torchvision.transforms import ToTensor
 

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -8,7 +8,6 @@
 import argparse
 
 import torch
-from torch.autograd import Variable
 
 import data
 


### PR DESCRIPTION
Since PyTorch 0.4.0, the `Variable` API has been deprecated: [PyTorch 0.4.0 Migration Guide](https://pytorch.org/blog/pytorch-0_4_0-migration-guide/)

Moreover, they're not being used in these codes. Shall we remove them?