### PR TITLE
Fixes bug when loading checkpoint of different GPU

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -180,6 +180,9 @@ def main_worker(gpu, ngpus_per_node, args):
             checkpoint = torch.load(args.resume)
             args.start_epoch = checkpoint['epoch']
             best_acc1 = checkpoint['best_acc1']
+            if args.gpu is not None:
+                # best_acc1 may be from a checkpoint from a different GPU
+                best_acc1 = best_acc1.to(args.gpu)
             model.load_state_dict(checkpoint['state_dict'])
             optimizer.load_state_dict(checkpoint['optimizer'])
             print("=> loaded checkpoint '{}' (epoch {})"


### PR DESCRIPTION
Lines 245 and 246 will always FAIL when a checkpoint is saved while running this code on a specific GPU, then something happens stopping training, then training is resumed on a different GPU. The error occurs because best_acc1 and acc1 are on different GPUs but are compared. This is a least-number-of-lines bug fix that does not impact other use cases.