### PR TITLE
[C++][DCGAN] Increment batch_index before the if statements?

### DIFF
--- a/cpp/dcgan/dcgan.cpp
+++ b/cpp/dcgan/dcgan.cpp
@@ -153,7 +153,7 @@ int main(int argc, const char* argv[]) {
           torch::binary_cross_entropy(fake_output, fake_labels);
       g_loss.backward();
       generator_optimizer.step();
-      batch_index++
+      batch_index++;
       if (batch_index % kLogInterval == 0) {
         std::printf(
             "\r[%2ld/%2ld][%3ld/%3ld] D_loss: %.4f | G_loss: %.4f",

--- a/cpp/dcgan/dcgan.cpp
+++ b/cpp/dcgan/dcgan.cpp
@@ -153,13 +153,13 @@ int main(int argc, const char* argv[]) {
           torch::binary_cross_entropy(fake_output, fake_labels);
       g_loss.backward();
       generator_optimizer.step();
-
+      batch_index++
       if (batch_index % kLogInterval == 0) {
         std::printf(
             "\r[%2ld/%2ld][%3ld/%3ld] D_loss: %.4f | G_loss: %.4f",
             epoch,
             kNumberOfEpochs,
-            ++batch_index,
+            batch_index,
             batches_per_epoch,
             d_loss.item<float>(),
             g_loss.item<float>());


### PR DESCRIPTION
I ran the example codes for [C++][DCGAN] but the 2 if statements in the nested for loop are not behaving as expected. The first one just prints the losses every epoch essentially since batch_index gets value 1 through the life of the program. As for the second one it seems to not save anything for the same reason as the first. Not sure if this code runs perfectly fine on other versions as I ran it on C++14. If I'm in the wrong then sorry I wasted your time with this PR.

Thanks