### PR TITLE
mnist_hogwild: correct test_epoch call

### DIFF
--- a/mnist_hogwild/train.py
+++ b/mnist_hogwild/train.py
@@ -33,7 +33,7 @@ def test(args, model, device, dataloader_kwargs):
         batch_size=args.batch_size, shuffle=True, num_workers=1,
         **dataloader_kwargs)
 
-    test_epoch(model, device, test_loader, device)
+    test_epoch(model, device, test_loader)
 
 
 def train_epoch(epoch, args, model, device, data_loader, optimizer):


### PR DESCRIPTION
Due to a commit adding CUDA support to mnist_hogwild (PR #508), a duplicate`device` variable was passed to the `test_epoch()` function, thereby preventing the main script from finishing. This commit removes the duplicate `device` input.