### PR TITLE
Consider PyTorch 1.1 for _download_url_to_file module path

### DIFF
--- a/fast_neural_style/download_saved_models.py
+++ b/fast_neural_style/download_saved_models.py
@@ -1,7 +1,7 @@
 import os
 import zipfile
 
-# PyTorch 1.1 moves _download_utl_to_file
+# PyTorch 1.1 moves _download_url_to_file
 #   from torch.utils.model_zoo to torch.hub
 # PyTorch 1.0 exists another _download_url_to_file
 #   2 argument

--- a/fast_neural_style/download_saved_models.py
+++ b/fast_neural_style/download_saved_models.py
@@ -1,7 +1,18 @@
 import os
 import zipfile
 
-from torch.utils.model_zoo import _download_url_to_file
+# PyTorch 1.1 moves _download_utl_to_file
+#   from torch.utils.model_zoo to torch.hub
+# PyTorch 1.0 exists another _download_url_to_file
+#   2 argument
+# TODO: If you remove support PyTorch 1.0 or older,
+#       You should remove torch.utils.model_zoo
+#       Ref. PyTorch #18758
+#         https://github.com/pytorch/pytorch/pull/18758/commits
+try:
+    from torch.utils.model_zoo import _download_url_to_file
+except ImportError:
+    from torch.hub import _download_url_to_file
 
 
 def unzip(source_filename, dest_dir):


### PR DESCRIPTION
PyTorch #18758 moves _download_utl_to_file module path.
This patch considers it