### PR TITLE
incorrect data parallelism

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -163,7 +163,7 @@ def main_worker(gpu, ngpus_per_node, args):
             model.features = torch.nn.DataParallel(model.features)
             model.cuda()
         else:
-            model = torch.nn.DataParallel(model).cuda()
+            model = torch.nn.DataParallel(model)
 
     # define loss function (criterion) and optimizer
     criterion = nn.CrossEntropyLoss().cuda(args.gpu)


### PR DESCRIPTION
removed `.cuda()` from `DataParallel` init since `.cuda()` moves it to a single GPU device