### PR TITLE
Fix neural_style model saving

### DIFF
--- a/fast_neural_style/neural_style/neural_style.py
+++ b/fast_neural_style/neural_style/neural_style.py
@@ -103,14 +103,14 @@ def train(args):
                 print(mesg)
 
             if args.checkpoint_model_dir is not None and (batch_id + 1) % args.checkpoint_interval == 0:
-                transformer.eval().cpu()
+                transformer.eval()
                 ckpt_model_filename = "ckpt_epoch_" + str(e) + "_batch_id_" + str(batch_id + 1) + ".pth"
                 ckpt_model_path = os.path.join(args.checkpoint_model_dir, ckpt_model_filename)
                 torch.save(transformer.state_dict(), ckpt_model_path)
-                transformer.to(device).train()
+                transformer.train()
 
     # save model
-    transformer.eval().cpu()
+    transformer.eval()
     save_model_filename = "epoch_" + str(args.epochs) + "_" + str(time.ctime()).replace(' ', '_') + "_" + str(
         args.content_weight) + "_" + str(args.style_weight) + ".model"
     save_model_path = os.path.join(args.save_model_dir, save_model_filename)
@@ -135,7 +135,7 @@ def stylize(args):
     else:
         with torch.no_grad():
             style_model = TransformerNet()
-            state_dict = torch.load(args.model)
+            state_dict = torch.load(args.model, map_location=device)
             # remove saved deprecated running_* keys in InstanceNorm from the checkpoint
             for k in list(state_dict.keys()):
                 if re.search(r'in\d+\.running_(mean|var)$', k):


### PR DESCRIPTION
According to https://pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-model-across-devices, there is no need to move a model to CPU before saving, and we should rely on using `map_location` in `torch.load` to move the model to the right device at model loading time.

The biggest issue with the current approach is that, in the near future, `model.cuda()` / `model.cpu()` / `model.to(device)` will assign new tensors to the `model`'s parameters, which in this case would break the optimizer created earlier in the code (https://github.com/pytorch/examples/blob/master/fast_neural_style/neural_style/neural_style.py#L47), because that optimizer would be tracking parameters that are no longer part of `model`.

cc. @gchanan 