### PR TITLE
Clean readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A repository showcasing examples of using [PyTorch](https://github.com/pytorch/pytorch)
 
-- [MNIST Convnets](mnist)
+- [Image classification (MNIST) using Convnets](mnist)
 - [Word level Language Modeling using LSTM RNNs](word_language_model)
 - [Training Imagenet Classifiers with Residual Networks](imagenet)
 - [Generative Adversarial Networks (DCGAN)](dcgan)
@@ -11,8 +11,8 @@ A repository showcasing examples of using [PyTorch](https://github.com/pytorch/p
 - [Hogwild training of shared ConvNets across multiple processes on MNIST](mnist_hogwild)
 - [Training a CartPole to balance in OpenAI Gym with actor-critic](reinforcement_learning)
 - [Natural Language Inference (SNLI) with GloVe vectors, LSTMs, and torchtext](snli)
-- [Time sequence prediction - create an LSTM to learn Sine waves](time_sequence_prediction)
-- [Neural style transfer algorithm](fast_neural_style)
+- [Time sequence prediction - use an LSTM to learn Sine waves](time_sequence_prediction)
+- [Implement the Neural Style Transfer algorithm on images](fast_neural_style)
 - [Several examples illustrating the C++ Frontend](cpp)
 
 Additionally, a list of good examples hosted in their own repositories:

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 A repository showcasing examples of using [PyTorch](https://github.com/pytorch/pytorch)
 
-- MNIST Convnets
-- Word level Language Modeling using LSTM RNNs
-- Training Imagenet Classifiers with Residual Networks
-- Generative Adversarial Networks (DCGAN)
-- Variational Auto-Encoders
-- Superresolution using an efficient sub-pixel convolutional neural network
-- Hogwild training of shared ConvNets across multiple processes on MNIST
-- Training a CartPole to balance in OpenAI Gym with actor-critic
-- Natural Language Inference (SNLI) with GloVe vectors, LSTMs, and torchtext
-- Time sequence prediction - create an LSTM to learn Sine waves
+- [MNIST Convnets](mnist)
+- [Word level Language Modeling using LSTM RNNs](word_language_model)
+- [Training Imagenet Classifiers with Residual Networks](imagenet)
+- [Generative Adversarial Networks (DCGAN)](dcgan)
+- [Variational Auto-Encoders](vae)
+- [Superresolution using an efficient sub-pixel convolutional neural network](super_resolution)
+- [Hogwild training of shared ConvNets across multiple processes on MNIST](mnist_hogwild)
+- [Training a CartPole to balance in OpenAI Gym with actor-critic](reinforcement_learning)
+- [Natural Language Inference (SNLI) with GloVe vectors, LSTMs, and torchtext](snli)
+- [Time sequence prediction - create an LSTM to learn Sine waves](time_sequence_prediction)
+- [Neural style transfer algorithm](fast_neural_style)
+- [Several examples illustrating the C++ Frontend](cpp)
 
 Additionally, a list of good examples hosted in their own repositories:
 


### PR DESCRIPTION
Added links to each of the examples in the README, and added a couple bullets for examples that weren't mentioned. 

This is the first part of the `examples` clean-up that will be part of the `tutorials` re-write.