### PR TITLE
Reflecting the change in VAE paper name

### DIFF
--- a/vae/README.md
+++ b/vae/README.md
@@ -1,7 +1,6 @@
 # Basic VAE Example
 
-This is an improved implementation of the paper [Stochastic Gradient VB and the
-Variational Auto-Encoder](http://arxiv.org/abs/1312.6114) by Kingma and Welling.
+This is an improved implementation of the paper [Auto-Encoding Variational Bayes](http://arxiv.org/abs/1312.6114) by Kingma and Welling.
 It uses ReLUs and the adam optimizer, instead of sigmoids and adagrad. These changes make the network converge much faster.
 
 ```bash


### PR DESCRIPTION
The authors had renamed the paper to 'Auto-Encoding Variational Bayes'. This is more familiar to the current research community. I have just renamed the README to its current title, which matches their ICLR 2013 version.