### PR TITLE
Fix load model when a single GPU is used

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -176,7 +176,12 @@ def main_worker(gpu, ngpus_per_node, args):
     if args.resume:
         if os.path.isfile(args.resume):
             print("=> loading checkpoint '{}'".format(args.resume))
-            checkpoint = torch.load(args.resume)
+            if args.gpu is None:
+                checkpoint = torch.load(args.resume)
+            else:
+                # Map model to be loaded to specified single gpu.
+                loc = 'cuda:{}'.format(args.gpu)
+                checkpoint = torch.load(args.resume, map_location=loc)
             args.start_epoch = checkpoint['epoch']
             best_acc1 = checkpoint['best_acc1']
             if args.gpu is not None:


### PR DESCRIPTION
This change is necessary for --resume and --evaluate methods when --gpu is specified. For example, if the model was trained on GPU 3 (on a machine with four GPUs: 0, 1, 2, and 3) and then you try to evaluate it on a machine with only 3 GPUs, you would get this error: 

RuntimeError: Attempting to deserialize object on CUDA device 3 but torch.cuda.device_count() is 3. Please use torch.load with map_location to map your storages to an existing device.

This change allows --evaluate and --resume functionalities to work correctly when a single GPU is used.