### PR TITLE
Prefixed `at::` wherever `Reduction::` is used

### DIFF
--- a/cpp/mnist/mnist.cpp
+++ b/cpp/mnist/mnist.cpp
@@ -99,7 +99,7 @@ void test(
                      output,
                      targets,
                      /*weight=*/{},
-                     Reduction::Sum)
+                     at::Reduction::Sum)
                      .template item<float>();
     auto pred = output.argmax(1);
     correct += pred.eq(targets).sum().template item<int64_t>();


### PR DESCRIPTION
According to [3397d4](https://github.com/pytorch/pytorch/commit/3397d41b8af2824495faaefc649c3c7e47f03bfb) in pytorch repo, which
1) Wrapped namespace `Reduction` in namespace `at`
2) Prefixed `at::` wherever `Reduction::` is used

It should be updated, unless it raise error: ‘Reduction’ has not been declared. 