### PR TITLE
MNIST Example: Correct typo in default value within help

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -75,7 +75,7 @@ def main():
     parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
                         help='input batch size for testing (default: 1000)')
     parser.add_argument('--epochs', type=int, default=14, metavar='N',
-                        help='number of epochs to train (default: 10)')
+                        help='number of epochs to train (default: 14)')
     parser.add_argument('--lr', type=float, default=1.0, metavar='LR',
                         help='learning rate (default: 1.0)')
     parser.add_argument('--gamma', type=float, default=0.7, metavar='M',


### PR DESCRIPTION
Tiny change, simply fix typo in the help string for --epochs.