### PR TITLE
fix: Namespace issue of Reduction in CPP MNIST

### DIFF
--- a/cpp/mnist/mnist.cpp
+++ b/cpp/mnist/mnist.cpp
@@ -99,7 +99,7 @@ void test(
                      output,
                      targets,
                      /*weight=*/{},
-                      Reduction::Sum)
+                     Reduction::Sum)
                      .template item<float>();
     auto pred = output.argmax(1);
     correct += pred.eq(targets).sum().template item<int64_t>();

--- a/cpp/mnist/mnist.cpp
+++ b/cpp/mnist/mnist.cpp
@@ -99,7 +99,7 @@ void test(
                      output,
                      targets,
                      /*weight=*/{},
-                     at::Reduction::Sum)
+                      Reduction::Sum)
                      .template item<float>();
     auto pred = output.argmax(1);
     correct += pred.eq(targets).sum().template item<int64_t>();


### PR DESCRIPTION
Issue #672 
- Changed the at::Reduction::Sum into Reduction::Sum

- with at namespace build is failing. without the at namespace, build successfully.

Ref: #672 
fixed: #672 

Signed-off-by: Arkadip <in2arkadipb13@gmail.com>