### PR TITLE
update CXX compiler from 11 to 14

### DIFF
--- a/cpp/dcgan/CMakeLists.txt
+++ b/cpp/dcgan/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 add_executable(dcgan dcgan.cpp)
 target_link_libraries(dcgan "${TORCH_LIBRARIES}")
-set_property(TARGET dcgan PROPERTY CXX_STANDARD 11)
+set_property(TARGET dcgan PROPERTY CXX_STANDARD 14)
 
 if (MSVC)
   file(GLOB TORCH_DLLS "${TORCH_INSTALL_PREFIX}/lib/*.dll")

--- a/cpp/regression/CMakeLists.txt
+++ b/cpp/regression/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
 project(regression)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(Torch REQUIRED)
 

--- a/cpp/transfer-learning/CMakeLists.txt
+++ b/cpp/transfer-learning/CMakeLists.txt
@@ -14,5 +14,5 @@ target_link_libraries(example "${TORCH_LIBRARIES}")
 target_link_libraries(classify ${OpenCV_LIBS})
 target_link_libraries(classify "${TORCH_LIBRARIES}")
 
-set_property(TARGET classify PROPERTY CXX_STANDARD 11)
-set_property(TARGET example PROPERTY CXX_STANDARD 11)
+set_property(TARGET classify PROPERTY CXX_STANDARD 14)
+set_property(TARGET example PROPERTY CXX_STANDARD 14)


### PR DESCRIPTION
According to [Tutorial Error for "Using the PyTorch C++ Frontend" #31037](https://github.com/pytorch/pytorch/issues/31037)
The latest libtorch version has been using some cpp 14 features. If we use cpp 11 for compile, it may import some errors like this `error: #error You need C++14 to compile PyTorch`
So I'm trying to update these demos.