### PR TITLE
Added continuous Bernoulli log normalizing constant to VAE

### DIFF
--- a/vae/main.py
+++ b/vae/main.py
@@ -7,6 +7,7 @@ from torch.nn import functional as F
 from torchvision import datasets, transforms
 from torchvision.utils import save_image
 
+
 parser = argparse.ArgumentParser(description='VAE MNIST Example')
 parser.add_argument('--batch-size', type=int, default=128, metavar='N',
                     help='input batch size for training (default: 128)')


### PR DESCRIPTION
We recently had a paper at NeurIPS 2019 (https://arxiv.org/abs/1907.06845 and https://papers.nips.cc/paper/9484-the-continuous-bernoulli-fixing-a-pervasive-error-in-variational-autoencoders) where we show that when using a binary cross entropy reconstruction term in a VAE when the data is not binarized, a correction term (the log normalizing constant of a distribution which we call continuous Bernoulli) should be included. This pull request implements this correction on the VAE example. Resulting samples are significantly sharper and the resulting VAE has a proper probabilistic interpretation.