### PR TITLE
Fix shebang in `run_python_examples.sh`

### DIFF
--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This script runs through the code in each of the python examples.
 # The purpose is just as an integrtion test, not to actually train
@@ -174,11 +174,10 @@ fi
 if [ "" == "$ERRORS" ]; then
   tput setaf 2
   echo "Completed successfully"
-else 
+else
   tput setaf 1
   echo "Some examples failed:"
   printf "$ERRORS"
 fi
 
 tput sgr0
-


### PR DESCRIPTION
Fixes #685

This script uses some bash-specific features such as
- `function` keyword
- `==` operator
- `FUNCNAME`