### PR TITLE
dcgan: using `fake` dataset still requires dataroot parameter

### DIFF
--- a/dcgan/main.py
+++ b/dcgan/main.py
@@ -15,7 +15,7 @@ import torchvision.utils as vutils
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--dataset', required=True, help='cifar10 | lsun | mnist |imagenet | folder | lfw | fake')
-parser.add_argument('--dataroot', required=True, help='path to dataset')
+parser.add_argument('--dataroot', required=False, help='path to dataset')
 parser.add_argument('--workers', type=int, help='number of data loading workers', default=2)
 parser.add_argument('--batchSize', type=int, default=64, help='input batch size')
 parser.add_argument('--imageSize', type=int, default=64, help='the height / width of the input image to network')
@@ -51,6 +51,9 @@ cudnn.benchmark = True
 
 if torch.cuda.is_available() and not opt.cuda:
     print("WARNING: You have a CUDA device, so you should probably run with --cuda")
+  
+if opt.dataroot is None and opt.dataset != 'fake':
+    raise ValueError("`dataroot` parameter is required for dataset \"%s\"" % opt.dataset)
 
 if opt.dataset in ['imagenet', 'folder', 'lfw']:
     # folder dataset

--- a/dcgan/main.py
+++ b/dcgan/main.py
@@ -52,7 +52,7 @@ cudnn.benchmark = True
 if torch.cuda.is_available() and not opt.cuda:
     print("WARNING: You have a CUDA device, so you should probably run with --cuda")
   
-if opt.dataroot is None and opt.dataset != 'fake':
+if opt.dataroot is None and str(opt.dataset).lower() != 'fake':
     raise ValueError("`dataroot` parameter is required for dataset \"%s\"" % opt.dataset)
 
 if opt.dataset in ['imagenet', 'folder', 'lfw']:


### PR DESCRIPTION
Fixes #698 


#### To reproduce:

```sh
cd dcgan
python main.py --dataset fake
```
