### PR TITLE
README.md: Add a definition of nhead

### DIFF
--- a/word_language_model/README.md
+++ b/word_language_model/README.md
@@ -47,6 +47,7 @@ optional arguments:
   --transformer_encoder_layers N   the number of layers in the encoder of the transformer model
   --transformer_decoder_layers N   the number of layers in the decoder of the transformer model
   --transformer_d_ff N             the number of nodes on the hidden layer in feed forward nn
+  --nhead                          the number of heads in the multiheadattention model
 ```
 
 With these arguments, a variety of models can be tested.


### PR DESCRIPTION
Added a definition of nhead in README.md of word_language_model example