### PR TITLE
fix loss calculation for RNN

### DIFF
--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -145,10 +145,10 @@ def evaluate(data_source):
             data, targets = get_batch(data_source, i)
             if args.model == 'Transformer':
                 output = model(data)
+                output = output.view(-1, ntokens)
             else:
                 output, hidden = model(data, hidden)
                 hidden = repackage_hidden(hidden)
-            # output_flat = output.view(-1, ntokens)
             total_loss += len(data) * criterion(output, targets).item()
     return total_loss / (len(data_source) - 1)
 
@@ -168,6 +168,7 @@ def train():
         model.zero_grad()
         if args.model == 'Transformer':
             output = model(data)
+            output = output.view(-1, ntokens)
         else:
             hidden = repackage_hidden(hidden)
             output, hidden = model(data, hidden)

--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -148,8 +148,8 @@ def evaluate(data_source):
             else:
                 output, hidden = model(data, hidden)
                 hidden = repackage_hidden(hidden)
-            output_flat = output.view(-1, ntokens)
-            total_loss += len(data) * criterion(output_flat, targets).item()
+            # output_flat = output.view(-1, ntokens)
+            total_loss += len(data) * criterion(output, targets).item()
     return total_loss / (len(data_source) - 1)
 
 
@@ -171,7 +171,7 @@ def train():
         else:
             hidden = repackage_hidden(hidden)
             output, hidden = model(data, hidden)
-        loss = criterion(output.view(-1, ntokens), targets)
+        loss = criterion(output, targets)
         loss.backward()
 
         # `clip_grad_norm` helps prevent the exploding gradient problem in RNNs / LSTMs.

--- a/word_language_model/model.py
+++ b/word_language_model/model.py
@@ -8,6 +8,7 @@ class RNNModel(nn.Module):
 
     def __init__(self, rnn_type, ntoken, ninp, nhid, nlayers, dropout=0.5, tie_weights=False):
         super(RNNModel, self).__init__()
+        self.ntoken = ntoken
         self.drop = nn.Dropout(dropout)
         self.encoder = nn.Embedding(ntoken, ninp)
         if rnn_type in ['LSTM', 'GRU']:
@@ -49,7 +50,8 @@ class RNNModel(nn.Module):
         output, hidden = self.rnn(emb, hidden)
         output = self.drop(output)
         decoded = self.decoder(output)
-        return decoded, hidden
+        decoded = decoded.view(-1, self.ntoken)
+        return F.log_softmax(decoded, dim=1), hidden
 
     def init_hidden(self, bsz):
         weight = next(self.parameters())


### PR DESCRIPTION
After removal of the CrossEntropyLoss, loss calculation for RNN is broken.
Currently it's taking NLLLoss of direct RNN output (not the LogSoftmax), resulting in negative losses.