### PR TITLE
Fix:: Loss function for RNN and Transformer

### DIFF
--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -101,7 +101,7 @@ if args.model == 'Transformer':
 else:
     model = model.RNNModel(args.model, ntokens, args.emsize, args.nhid, args.nlayers, args.dropout, args.tied).to(device)
 
-criterion = nn.NLLLoss()
+criterion = nn.NLLLoss() if args.model == 'Transformer' else nn.CrossEntropyLoss()
 
 ###############################################################################
 # Training code


### PR DESCRIPTION
See [commit](https://github.com/pytorch/examples/commit/180051313c8b0fc9b556bd4ba55bc1ea2c48740f).
using `nn.NLLLoss()` makes the RNN model not compatible with the framework.
because [here](https://github.com/pytorch/examples/blob/master/word_language_model/model.py#L52) in RNN, return value of `output` variable is pure `logit` and [here](https://github.com/pytorch/examples/blob/master/word_language_model/model.py#L150) in Transformer, `output` variable is `log_softmax()`.
Possible conflict [here](https://github.com/pytorch/examples/blob/master/word_language_model/main.py#L174).
There could be more elegant solutions. But I preferred to edit `main.py` wrapper rather than changing the `model.py`.
@soumith 