### PR TITLE
Fix cpp/mnist CMakeList build.

### DIFF
--- a/cpp/mnist/CMakeLists.txt
+++ b/cpp/mnist/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(mnist)
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(Torch REQUIRED)
 


### PR DESCRIPTION
Fixes error: `error: You need C++14 to compile PyTorch`.

Related: https://github.com/pytorch/pytorch/issues/31037