### PR TITLE
Update dcgan.cpp

### DIFF
--- a/cpp/dcgan/dcgan.cpp
+++ b/cpp/dcgan/dcgan.cpp
@@ -121,9 +121,9 @@ int main(int argc, const char* argv[]) {
       torch::data::DataLoaderOptions().batch_size(kBatchSize).workers(2));
 
   torch::optim::Adam generator_optimizer(
-      generator->parameters(), torch::optim::AdamOptions(2e-4).beta1(0.5));
+      generator->parameters(), torch::optim::AdamOptions(2e-4).betas(std::make_tuple (0.5, 0.5)));
   torch::optim::Adam discriminator_optimizer(
-      discriminator->parameters(), torch::optim::AdamOptions(2e-4).beta1(0.5));
+      discriminator->parameters(), torch::optim::AdamOptions(2e-4).betas(std::make_tuple (0.5, 0.5)));
 
   if (kRestoreFromCheckpoint) {
     torch::load(generator, "generator-checkpoint.pt");


### PR DESCRIPTION
Fix AdamOptions initialization error with latest libtorch.

Error without this change: 

```
dcgan.cpp:124:64: error: no member named 'beta1' in 'torch::optim::AdamOptions'
      generator->parameters(), torch::optim::AdamOptions(2e-4).beta1(0.5));
```