### PR TITLE
Correcting the pipeline rpc example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ snli/results
 word_language_model/model.pt
 fast_neural_style/saved_models
 fast_neural_style/saved_models.zip
+
+# vi backups
+*~

--- a/distributed/rpc/pipeline/main.py
+++ b/distributed/rpc/pipeline/main.py
@@ -226,7 +226,8 @@ image_w = 128
 image_h = 128
 
 
-def run_master(num_split):
+def run_master(split_size):
+
     # put the two model parts on worker1 and worker2 respectively
     model = DistResNet50(split_size, ["worker1", "worker2"])
     loss_fn = nn.MSELoss()


### PR DESCRIPTION
This PR fixes the error in `distributed/rpc/pipeline/main.py`. Here is how it looks like:

```
distributed/rpc/pipeline$ python ./main.py
Traceback (most recent call last):
  File "./main.py", line 286, in <module>
    mp.spawn(run_worker, args=(world_size, num_split), nprocs=world_size, join=True)
  File "/anaconda/envs/mypytorchenv_gpu/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 200, in spawn
    return start_processes(fn, args, nprocs, join, daemon, start_method='spawn')
  File "/anaconda/envs/mypytorchenv_gpu/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 158, in start_processes
    while not context.join():
  File "/anaconda/envs/mypytorchenv_gpu/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 119, in join
    raise Exception(msg)
Exception:

-- Process 0 terminated with the following error:
Traceback (most recent call last):
  File "/anaconda/envs/mypytorchenv_gpu/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 20, in _wrap
    fn(i, *args)
  File "src/pytorch-examples/distributed/rpc/pipeline/main.py", line 268, in run_worker
    run_master(num_split)
  File "src/pytorch-examples/distributed/rpc/pipeline/main.py", line 231, in run_master
    model = DistResNet50(split_size, ["worker1", "worker2"])
NameError: name 'split_size' is not defined
```
