### PR TITLE
Fix Parameter Server Example

### DIFF
--- a/distributed/rpc/parameter_server/rpc_parameter_server.py
+++ b/distributed/rpc/parameter_server/rpc_parameter_server.py
@@ -202,7 +202,7 @@ def get_accuracy(test_loader, model):
         and torch.cuda.is_available() else "cpu")
     with torch.no_grad():
         for i, (data, target) in enumerate(test_loader):
-            out = model(data, -1)
+            out = model(data)
             pred = out.argmax(dim=1, keepdim=True)
             pred, target = pred.to(device), target.to(device)
             correct = pred.eq(target.view_as(pred)).sum().item()


### PR DESCRIPTION
This fixes incorrect arguments passed to `model.forward` in the RPC Parameter Server training example.