### PR TITLE
[word_language_model] Fix initialization of weight of Decoder

### DIFF
--- a/word_language_model/model.py
+++ b/word_language_model/model.py
@@ -42,7 +42,7 @@ class RNNModel(nn.Module):
     def init_weights(self):
         initrange = 0.1
         nn.init.uniform_(self.encoder.weight, -initrange, initrange)
-        nn.init.zeros_(self.decoder)
+        nn.init.zeros_(self.decoder.weight)
         nn.init.uniform_(self.decoder.weight, -initrange, initrange)
 
     def forward(self, input, hidden):


### PR DESCRIPTION
`nn.init.zeros_(self.decoder)` throws this error `AttributeError: module 'torch.nn.init' has no attribute 'zero_'` because the weights weren't passed.