### PR TITLE
[word_language_model] Fix grad in-place operation

### DIFF
--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -178,7 +178,7 @@ def train():
         # `clip_grad_norm` helps prevent the exploding gradient problem in RNNs / LSTMs.
         torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip)
         for p in model.parameters():
-            p.add_(-lr, p.grad)
+            p.data.add_(-lr, p.grad)
 
         total_loss += loss.item()
 


### PR DESCRIPTION
`p.add_(-lr, p.grad)` throws `RuntimeError: a leaf Variable that requires grad is being used in an in-place operation`, using `p.data.add_(-lr, p.grad)` fixes this issue.