### PR TITLE
word_language_model: Fix Transformer init_weights

### DIFF
--- a/word_language_model/model.py
+++ b/word_language_model/model.py
@@ -133,7 +133,7 @@ class TransformerModel(nn.Module):
     def init_weights(self):
         initrange = 0.1
         nn.init.uniform_(self.encoder.weight, -initrange, initrange)
-        nn.init.zeros_(self.decoder)
+        nn.init.zeros_(self.decoder.weight)
         nn.init.uniform_(self.decoder.weight, -initrange, initrange)
 
     def forward(self, src, has_mask=True):


### PR DESCRIPTION
Model was not getting initialized property since it was using the
decoder object instead of decoder weight to initialize zeros.

Closes https://github.com/pytorch/examples/issues/783

Solution can be attributed to @mjoukamaa

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>