### PR TITLE
Adding Batch RPC example

### DIFF
--- a/distributed/rpc/batch/README.md
+++ b/distributed/rpc/batch/README.md
@@ -1,0 +1,17 @@
+# Examples For Asynchronous RPC User Functions
+
+This folder contains two examples for [`@rpc.functions.async_execution`](https://pytorch.org/docs/master/rpc.html#torch.distributed.rpc.functions.async_execution):
+
+1. Synchronized Batch Update Parameter Server: uses `@rpc.functions.async_execution`
+    for parameter update and retrieving. This serves as a simple starter example
+    for batch RPC.
+    ```
+    pip install -r requirements.txt
+    python parameter_server.py
+    ```
+2. Multi-Observer with Batch-Processing Agent: uses `@rpc.functions.async_execution`
+    to run multiple observed states through the policy to get actions.
+    ```
+    pip install -r requirements.txt
+    python reinforce.py
+    ```

--- a/distributed/rpc/batch/parameter_server.py
+++ b/distributed/rpc/batch/parameter_server.py
@@ -1,0 +1,144 @@
+import os
+import threading
+from datetime import datetime
+
+import torch
+import torch.distributed.rpc as rpc
+import torch.multiprocessing as mp
+import torch.nn as nn
+from torch import optim
+
+import torchvision
+
+
+batch_size = 20
+image_w = 64
+image_h = 64
+num_classes = 30
+batch_update_size = 5
+num_batches = 6
+
+
+def timed_log(text):
+    print(f"{datetime.now().strftime('%H:%M:%S')} {text}")
+
+
+class BatchUpdateParameterServer(object):
+
+    def __init__(self, batch_update_size=batch_update_size):
+        self.model = torchvision.models.resnet50(num_classes=num_classes)
+        self.lock = threading.Lock()
+        self.future_model = torch.futures.Future()
+        self.batch_update_size = batch_update_size
+        self.curr_update_size = 0
+        self.optimizer = optim.SGD(self.model.parameters(), lr=0.001, momentum=0.9)
+        for p in self.model.parameters():
+            p.grad = torch.zeros_like(p)
+
+    def get_model(self):
+        return self.model
+
+    @staticmethod
+    @rpc.functions.async_execution
+    def update_and_fetch_model(ps_rref, grads):
+        self = ps_rref.local_value()
+        timed_log(f"PS got {self.curr_update_size}/{batch_update_size} updates")
+        for p, g in zip(self.model.parameters(), grads):
+            p.grad += g
+        with self.lock:
+            self.curr_update_size += 1
+            fut = self.future_model
+
+            if self.curr_update_size >= self.batch_update_size:
+                for p in self.model.parameters():
+                    p.grad /= self.batch_update_size
+                self.curr_update_size = 0
+                self.optimizer.step()
+                self.optimizer.zero_grad()
+                fut.set_result(self.model)
+                timed_log("PS updated model")
+                self.future_model = torch.futures.Future()
+
+        return fut
+
+
+class Trainer(object):
+
+    def __init__(self, ps_rref):
+        self.ps_rref = ps_rref
+        self.loss_fn = nn.MSELoss()
+        self.one_hot_indices = torch.LongTensor(batch_size) \
+                                    .random_(0, num_classes) \
+                                    .view(batch_size, 1)
+
+    def get_next_batch(self):
+        for _ in range(num_batches):
+            inputs = torch.randn(batch_size, 3, image_w, image_h)
+            labels = torch.zeros(batch_size, num_classes) \
+                        .scatter_(1, self.one_hot_indices, 1)
+            yield inputs.cuda(), labels.cuda()
+
+    def train(self):
+        name = rpc.get_worker_info().name
+        m = self.ps_rref.rpc_sync().get_model().cuda()
+        for inputs, labels in self.get_next_batch():
+            timed_log(f"{name} processing one batch")
+            self.loss_fn(m(inputs), labels).backward()
+            timed_log(f"{name} reporting grads")
+            m = rpc.rpc_sync(
+                self.ps_rref.owner(),
+                BatchUpdateParameterServer.update_and_fetch_model,
+                args=(self.ps_rref, [p.grad for p in m.cpu().parameters()]),
+            ).cuda()
+            timed_log(f"{name} got updated model")
+
+
+def run_trainer(ps_rref):
+    trainer = Trainer(ps_rref)
+    trainer.train()
+
+
+def run_ps(trainers):
+    timed_log("Start training")
+    ps_rref = rpc.RRef(BatchUpdateParameterServer())
+    futs = []
+    for trainer in trainers:
+        futs.append(
+            rpc.rpc_async(trainer, run_trainer, args=(ps_rref,))
+        )
+
+    torch.futures.wait_all(futs)
+    timed_log("Finish training")
+
+
+def run(rank, world_size):
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '29500'
+    options=rpc.ProcessGroupRpcBackendOptions(
+        num_send_recv_threads=16,
+        rpc_timeout=0  # infinite timeout
+     )
+    if rank != 0:
+        rpc.init_rpc(
+            f"trainer{rank}",
+            rank=rank,
+            world_size=world_size,
+            rpc_backend_options=options
+        )
+        # trainer passively waiting for ps to kick off training iterations
+    else:
+        rpc.init_rpc(
+            "ps",
+            rank=rank,
+            world_size=world_size,
+            rpc_backend_options=options
+        )
+        run_ps([f"trainer{r}" for r in range(1, world_size)])
+
+    # block until all rpcs finish
+    rpc.shutdown()
+
+
+if __name__=="__main__":
+    world_size = batch_update_size + 1
+    mp.spawn(run, args=(world_size, ), nprocs=world_size, join=True)

--- a/distributed/rpc/batch/reinforce.py
+++ b/distributed/rpc/batch/reinforce.py
@@ -1,0 +1,256 @@
+import argparse
+import gym
+import os
+import threading
+import time
+
+import torch
+import torch.distributed.rpc as rpc
+import torch.multiprocessing as mp
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from torch.distributed.rpc import RRef, rpc_sync, rpc_async, remote
+from torch.distributions import Categorical
+
+# demonstrating using rpc.functions.async_execution to speed up training
+
+NUM_STEPS = 500
+AGENT_NAME = "agent"
+OBSERVER_NAME = "observer{}"
+
+parser = argparse.ArgumentParser(description='PyTorch RPC Batch RL example')
+parser.add_argument('--gamma', type=float, default=1.0, metavar='G',
+                    help='discount factor (default: 1.0)')
+parser.add_argument('--seed', type=int, default=543, metavar='N',
+                    help='random seed (default: 543)')
+parser.add_argument('--num-episode', type=int, default=10, metavar='E',
+                    help='number of episodes (default: 10)')
+args = parser.parse_args()
+
+torch.manual_seed(args.seed)
+
+
+class Policy(nn.Module):
+    r"""
+    Borrowing the ``Policy`` class from the Reinforcement Learning example.
+    Copying the code to make these two examples independent.
+    See https://github.com/pytorch/examples/tree/master/reinforcement_learning
+    """
+    def __init__(self, batch=True):
+        super(Policy, self).__init__()
+        self.affine1 = nn.Linear(4, 128)
+        self.dropout = nn.Dropout(p=0.6)
+        self.affine2 = nn.Linear(128, 2)
+        self.dim = 2 if batch else 1
+
+    def forward(self, x):
+        x = self.affine1(x)
+        x = self.dropout(x)
+        x = F.relu(x)
+        action_scores = self.affine2(x)
+        return F.softmax(action_scores, dim=self.dim)
+
+
+class Observer:
+    r"""
+    An observer has exclusive access to its own environment. Each observer
+    captures the state from its environment, and send the state to the agent to
+    select an action. Then, the observer applies the action to its environment
+    and reports the reward to the agent.
+
+    It is true that CartPole-v1 is a relatively inexpensive environment, and it
+    might be an overkill to use RPC to connect observers and trainers in this
+    specific use case. However, the main goal of this tutorial to how to build
+    an application using the RPC API. Developers can extend the similar idea to
+    other applications with much more expensive environment.
+    """
+    def __init__(self, batch=True):
+        self.id = rpc.get_worker_info().id - 1
+        self.env = gym.make('CartPole-v1')
+        self.env.seed(args.seed)
+        self.select_action = Agent.select_action_batch if batch else Agent.select_action
+
+    def run_episode(self, agent_rref, n_steps):
+        r"""
+        Run one episode of n_steps.
+
+        Arguments:
+            agent_rref (RRef): an RRef referencing the agent object.
+            n_steps (int): number of steps in this episode
+        """
+        state, ep_reward = self.env.reset(), NUM_STEPS
+        rewards = torch.zeros(n_steps)
+        start_step = 0
+        for step in range(n_steps):
+            state = torch.from_numpy(state).float().unsqueeze(0)
+            # send the state to the agent to get an action
+            action = rpc.rpc_sync(
+                agent_rref.owner(),
+                self.select_action,
+                args=(agent_rref, self.id, state)
+            )
+
+            # apply the action to the environment, and get the reward
+            state, reward, done, _ = self.env.step(action)
+            rewards[step] = reward
+
+            if done or step + 1 >= n_steps:
+                curr_rewards = rewards[start_step:(step + 1)]
+                R = 0
+                for i in range(curr_rewards.numel() -1, -1, -1):
+                    R = curr_rewards[i] + args.gamma * R
+                    curr_rewards[i] = R
+                state = self.env.reset()
+                if start_step == 0:
+                    ep_reward = min(ep_reward, step - start_step + 1)
+                start_step = step + 1
+
+        return [rewards, ep_reward]
+
+
+class Agent:
+    def __init__(self, world_size, batch=True):
+        self.ob_rrefs = []
+        self.agent_rref = RRef(self)
+        self.rewards = {}
+        self.policy = Policy(batch).cuda()
+        self.optimizer = optim.Adam(self.policy.parameters(), lr=1e-2)
+        self.running_reward = 0
+
+        for ob_rank in range(1, world_size):
+            ob_info = rpc.get_worker_info(OBSERVER_NAME.format(ob_rank))
+            self.ob_rrefs.append(remote(ob_info, Observer, args=(batch,)))
+            self.rewards[ob_info.id] = []
+
+        self.states = torch.zeros(len(self.ob_rrefs), 1, 4)
+        self.batch = batch
+        # With batching, saved_log_probs contains a list of tensors, where each
+        # tensor contains probs from all observers in one step.
+        # Without batching, saved_log_probs is a dictionary where the key is the
+        # observer id and the value is a list of probs for that observer.
+        self.saved_log_probs = [] if self.batch else {k:[] for k in range(len(self.ob_rrefs))}
+        self.future_actions = torch.futures.Future()
+        self.lock = threading.Lock()
+        self.pending_states = len(self.ob_rrefs)
+
+    @staticmethod
+    @rpc.functions.async_execution
+    def select_action_batch(agent_rref, ob_id, state):
+        r"""
+        Batching select_action: In each step, the agent waits for states from
+        all observers, and process them together. This helps to reduce the
+        number of CUDA kernels launched and hence speed up amortized inference
+        speed.
+        """
+        self = agent_rref.local_value()
+        self.states[ob_id].copy_(state)
+        future_action = self.future_actions.then(
+            lambda future_actions: future_actions.wait()[ob_id].item()
+        )
+
+        with self.lock:
+            self.pending_states -= 1
+            if self.pending_states == 0:
+                self.pending_states = len(self.ob_rrefs)
+                probs = self.policy(self.states.cuda())
+                m = Categorical(probs)
+                actions = m.sample()
+                self.saved_log_probs.append(m.log_prob(actions).t()[0])
+                future_actions = self.future_actions
+                self.future_actions = torch.futures.Future()
+                future_actions.set_result(actions.cpu())
+        return future_action
+
+    @staticmethod
+    def select_action(agent_rref, ob_id, state):
+        r"""
+        Non-batching select_action, return the action right away.
+        """
+        self = agent_rref.local_value()
+        probs = self.policy(state.cuda())
+        m = Categorical(probs)
+        action = m.sample()
+        self.saved_log_probs[ob_id].append(m.log_prob(action))
+        return action.item()
+
+    def run_episode(self, n_steps=0):
+        r"""
+        Run one episode. The agent will tell each oberser to run one episode
+        with n_steps. Then it collects all actions and rewards, and use those to
+        train the policy.
+        """
+        futs = []
+        for ob_rref in self.ob_rrefs:
+            # make async RPC to kick off an episode on all observers
+            futs.append(ob_rref.rpc_async().run_episode(self.agent_rref, n_steps))
+
+        # wait until all obervers have finished this episode
+        rets = torch.futures.wait_all(futs)
+        rewards = torch.stack([ret[0] for ret in rets]).cuda().t()
+        ep_rewards = sum([ret[1] for ret in rets]) / len(rets)
+
+        if self.batch:
+            probs = torch.stack(self.saved_log_probs)
+        else:
+            probs = [torch.stack(self.saved_log_probs[i]) for i in range(len(rets))]
+            probs = torch.stack(probs)
+
+        policy_loss = -probs * rewards / len(rets)
+        policy_loss.sum().backward()
+        self.optimizer.step()
+        self.optimizer.zero_grad()
+
+        # reset variables
+        self.saved_log_probs = [] if self.batch else {k:[] for k in range(len(self.ob_rrefs))}
+        self.states = torch.zeros(len(self.ob_rrefs), 1, 4)
+
+        # calculate running rewards
+        self.running_reward = 0.5 * ep_rewards + 0.5 * self.running_reward
+        return ep_rewards, self.running_reward
+
+
+def run_worker(rank, world_size, n_episode, batch, print_log=True):
+    r"""
+    This is the entry point for all processes. The rank 0 is the agent. All
+    other ranks are observers.
+    """
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '29500'
+    if rank == 0:
+        # rank0 is the agent
+        rpc.init_rpc(AGENT_NAME, rank=rank, world_size=world_size)
+
+        agent = Agent(world_size, batch)
+        for i_episode in range(n_episode):
+            last_reward, running_reward = agent.run_episode(n_steps=NUM_STEPS)
+
+            if print_log:
+                print('Episode {}\tLast reward: {:.2f}\tAverage reward: {:.2f}'.format(
+                    i_episode, last_reward, running_reward))
+    else:
+        # other ranks are the observer
+        rpc.init_rpc(OBSERVER_NAME.format(rank), rank=rank, world_size=world_size)
+        # observers passively waiting for instructions from agents
+    rpc.shutdown()
+
+
+def main():
+    for world_size in range(2, 12):
+        delays = []
+        for batch in [True, False]:
+            tik = time.time()
+            mp.spawn(
+                run_worker,
+                args=(world_size, args.num_episode, batch),
+                nprocs=world_size,
+                join=True
+            )
+            tok = time.time()
+            delays.append(tok - tik)
+
+        print(f"{world_size}, {delays[0]}, {delays[1]}")
+
+
+if __name__ == '__main__':
+    main()

--- a/distributed/rpc/batch/requirements.txt
+++ b/distributed/rpc/batch/requirements.txt
@@ -1,0 +1,4 @@
+torch==1.6.0
+torchvision==0.7.0
+numpy
+gym


### PR DESCRIPTION
This PR adds two examples for `@rpc.functions.async_execution` decorator.
    
1. A synchronized batch-pdate Parameter Server example.
2. A batch-processing reinforcement learning example.