### PR TITLE
netG to be in eval() mode for netG's output on fixed_noise

### DIFF
--- a/dcgan/main.py
+++ b/dcgan/main.py
@@ -261,8 +261,11 @@ for epoch in range(opt.niter):
             vutils.save_image(real_cpu,
                     '%s/real_samples.png' % opt.outf,
                     normalize=True)
-            fake = netG(fixed_noise)
-            vutils.save_image(fake.detach(),
+            netG.eval()
+            with torch.no_grad():
+                fake = netG(fixed_noise).detach()
+            netG.train()
+            vutils.save_image(fake,
                     '%s/fake_samples_epoch_%03d.png' % (opt.outf, epoch),
                     normalize=True)
 


### PR DESCRIPTION
For G's output on fixed_noise, netG should be in eval() mode for Batch_Norm layers to use running mean & running variance instead of batch_statistics.
netG's eval() mode makes sure that that G's output will also be valid on a single instance of fixed_noise e.g fixed_noise = torch.randn(1, nz, 1, 1, device=device).
After G's output has been obtained, we reset netG to train() mode to allow G's training further.