### PR TITLE
Run CI daily

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,14 @@
 name: Run Examples
 
 on:
- push:
-   branches: [ master ]
- pull_request:
-   branches: [ master ]
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    # Every day at 3:00am
+    - cron: '0 3 * * *'
+        
 
 jobs:
   test:
@@ -27,5 +31,12 @@ jobs:
     - name: Run Tests
       run: |
         ./run_python_examples.sh "install_deps,run_all,clean"
-
+    - name: Open issue on failure
+      if: ${{ failure() && github.event_name  == 'schedule' }}
+      uses: rishabhgupta/git-action-issue@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        title: Daily CI failed
+        body:  Commit ${{ github.sha }} daily scheduled [CI run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) failed, please check why
+        assignees: ''
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # PyTorch Examples
 ![Run Examples](https://github.com/pytorch/examples/workflows/Run%20Examples/badge.svg)
 
+WARNING: if you fork this repo, github actions will run daily on it. To disable
+this, go to <myuser>/examples/settings/actions and Disable Actions for this
+repository
+
 A repository showcasing examples of using [PyTorch](https://github.com/pytorch/pytorch)
 
 - [Image classification (MNIST) using Convnets](mnist)


### PR DESCRIPTION
xref pytorch/pytorch#32004

Run github actions CI once a day (at 3:00) and if it fails, open an issue. mattip/pytorch-examples#21 is a forced example of such an issue. A few things to note:
- The main purpose of this action is to consistently test this repo against pytorch nightly builds, to see if some new pytorch "feature" breaks one of the examples.
- Anyone who forks this repo will, by default, get this scheduled action. I added a note to the README. We could also add a step to emit an issue `if {{ github.repository_owner != 'pytorch' }}` which would hopefully get people's attention :). By default forks do not have issues, so I am not sure what would happen. Forking this repo does seem like a popular thing to do: there are 64.k forks. Searching for a way to disable via the yml led me to [this discussion](https://github.community/t/how-can-i-disable-a-github-action/17049) which seems to indicate it cannot be done right now. Another option would be to move from github actions (which are available on all public repos) to travis or circleci, which would require action on part of the fork to enable it. I can pivot this PR to do that, but a admin would have to enable another CI service.
- I _hope_ someone is getting mails on all new issues in this repo, otherwise the issue will not get much attention.