### PR TITLE
use reshape instead of view in accuracy

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -420,7 +420,7 @@ def accuracy(output, target, topk=(1,)):
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+            correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
 


### PR DESCRIPTION
Per title. Layout of `pred` is now correctly propagated so that `correct` is not contiguous. 