### PR TITLE
Fix RPC examples to use TensorPipeRpcBackendOptions.

### DIFF
--- a/distributed/rpc/batch/parameter_server.py
+++ b/distributed/rpc/batch/parameter_server.py
@@ -114,8 +114,8 @@ def run_ps(trainers):
 def run(rank, world_size):
     os.environ['MASTER_ADDR'] = 'localhost'
     os.environ['MASTER_PORT'] = '29500'
-    options=rpc.ProcessGroupRpcBackendOptions(
-        num_send_recv_threads=16,
+    options=rpc.TensorPipeRpcBackendOptions(
+        num_worker_threads=16,
         rpc_timeout=0  # infinite timeout
      )
     if rank != 0:

--- a/distributed/rpc/ddp_rpc/main.py
+++ b/distributed/rpc/ddp_rpc/main.py
@@ -8,7 +8,7 @@ import torch.distributed.autograd as dist_autograd
 from torch.distributed.optim import DistributedOptimizer
 import torch.distributed.rpc as rpc
 from torch.distributed.rpc import RRef
-from torch.distributed.rpc import ProcessGroupRpcBackendOptions
+from torch.distributed.rpc import TensorPipeRpcBackendOptions
 import torch.multiprocessing as mp
 from torch.nn.parallel import DistributedDataParallel as DDP
 import torch.optim as optim
@@ -117,7 +117,7 @@ def run_worker(rank, world_size):
 
     # We need to use different port numbers in TCP init_method for init_rpc and
     # init_process_group to avoid port conflicts.
-    rpc_backend_options = ProcessGroupRpcBackendOptions()
+    rpc_backend_options = TensorPipeRpcBackendOptions()
     rpc_backend_options.init_method='tcp://localhost:29501'
 
     # Rank 2 is master, 3 is ps and 0 and 1 are trainers.

--- a/distributed/rpc/pipeline/main.py
+++ b/distributed/rpc/pipeline/main.py
@@ -219,7 +219,7 @@ def run_master(split_size):
 def run_worker(rank, world_size, num_split):
     os.environ['MASTER_ADDR'] = 'localhost'
     os.environ['MASTER_PORT'] = '29500'
-    options = rpc.ProcessGroupRpcBackendOptions(num_send_recv_threads=256)
+    options = rpc.TensorPipeRpcBackendOptions(num_worker_threads=256)
 
     if rank == 0:
         rpc.init_rpc(


### PR DESCRIPTION
Summary: Since TensorPipe is going to be the default backend in 1.7, we
should change our examples to use this backend. Some examples were
failing since the default was TensorPipe but we were passing in
ProcessGroupBackendOptions.

Test Plan: Run the test examples.