### PR TITLE
Fix random seed bug of DDP in the ImageNet example

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -81,9 +81,6 @@ def main():
     args = parser.parse_args()
 
     if args.seed is not None:
-        random.seed(args.seed)
-        torch.manual_seed(args.seed)
-        cudnn.deterministic = True
         warnings.warn('You have chosen to seed training. '
                       'This will turn on the CUDNN deterministic setting, '
                       'which can slow down your training considerably! '
@@ -115,6 +112,11 @@ def main():
 def main_worker(gpu, ngpus_per_node, args):
     global best_acc1
     args.gpu = gpu
+    
+    if args.seed is not None:
+        random.seed(args.seed)
+        torch.manual_seed(args.seed)
+        cudnn.deterministic = True
 
     if args.gpu is not None:
         print("Use GPU: {} for training".format(args.gpu))


### PR DESCRIPTION
the random seed has to be set in the main_worker, not in the `def main()`.
I found that although the seed is set in `def main()`,
each process in distributed training has individual & different seeds.