### PR TITLE
Simplify some lines in time_sequence_prediction

### DIFF
--- a/time_sequence_prediction/train.py
+++ b/time_sequence_prediction/train.py
@@ -32,7 +32,7 @@ class Sequence(nn.Module):
             h_t2, c_t2 = self.lstm2(h_t, (h_t2, c_t2))
             output = self.linear(h_t2)
             outputs += [output]
-        outputs = torch.stack(outputs, 1).squeeze(2)
+        outputs = torch.cat(outputs, dim=1)
         return outputs
 
 

--- a/time_sequence_prediction/train.py
+++ b/time_sequence_prediction/train.py
@@ -22,7 +22,7 @@ class Sequence(nn.Module):
         h_t2 = torch.zeros(input.size(0), 51, dtype=torch.double)
         c_t2 = torch.zeros(input.size(0), 51, dtype=torch.double)
 
-        for i, input_t in enumerate(input.chunk(input.size(1), dim=1)):
+        for input_t in input.chunk(input.size(1), dim=1):
             h_t, c_t = self.lstm1(input_t, (h_t, c_t))
             h_t2, c_t2 = self.lstm2(h_t, (h_t2, c_t2))
             output = self.linear(h_t2)

--- a/time_sequence_prediction/train.py
+++ b/time_sequence_prediction/train.py
@@ -22,7 +22,7 @@ class Sequence(nn.Module):
         h_t2 = torch.zeros(input.size(0), 51, dtype=torch.double)
         c_t2 = torch.zeros(input.size(0), 51, dtype=torch.double)
 
-        for input_t in input.chunk(input.size(1), dim=1):
+        for input_t in input.split(1, dim=1):
             h_t, c_t = self.lstm1(input_t, (h_t, c_t))
             h_t2, c_t2 = self.lstm2(h_t, (h_t2, c_t2))
             output = self.linear(h_t2)


### PR DESCRIPTION
This PR simplifies some lines in `time_sequence_prediction/train.py`.
* The variable `i` in line 25 is unused.
* The combination of `torch.stack` and `torch.squeeze` in line 35 can be replaced with a `torch.cat`.
* `input.chunk(input.size(1), dim=1)` in line 25 is identical to `input.split(1, dim=1)`.

The last 2 changes might not be necessary, so please let me know if you want me to undo them. Thanks!