### PR TITLE
MNIST example: use regular dropout rather than dropout2d

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -13,8 +13,8 @@ class Net(nn.Module):
         super(Net, self).__init__()
         self.conv1 = nn.Conv2d(1, 32, 3, 1)
         self.conv2 = nn.Conv2d(32, 64, 3, 1)
-        self.dropout1 = nn.Dropout2d(0.25)
-        self.dropout2 = nn.Dropout2d(0.5)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
         self.fc1 = nn.Linear(9216, 128)
         self.fc2 = nn.Linear(128, 10)
 


### PR DESCRIPTION
Using dropout2d does not really make sense for the second dropout since the data is flattened at that point (but it works accidentally). Furthermore, since this example copies the one from Keras (https://github.com/keras-team/keras/blob/master/examples/mnist_cnn.py) it might be better to follow that example (regular dropout). 

No noticeable performance changes.