### PR TITLE
fixed conditions about using single GPU

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -159,6 +159,8 @@ def main_worker(gpu, ngpus_per_node, args):
     elif args.gpu is not None:
         torch.cuda.set_device(args.gpu)
         model = model.cuda(args.gpu)
+    elif torch.cuda.device_count() == 1:
+        model = model.cuda()
     else:
         # DataParallel will divide and allocate batch_size to all available GPUs
         if args.arch.startswith('alexnet') or args.arch.startswith('vgg'):
@@ -281,9 +283,8 @@ def train(train_loader, model, criterion, optimizer, epoch, args):
         # measure data loading time
         data_time.update(time.time() - end)
 
-        if args.gpu is not None:
-            images = images.cuda(args.gpu, non_blocking=True)
         if torch.cuda.is_available():
+            images = images.cuda(args.gpu, non_blocking=True)
             target = target.cuda(args.gpu, non_blocking=True)
 
         # compute output
@@ -325,9 +326,8 @@ def validate(val_loader, model, criterion, args):
     with torch.no_grad():
         end = time.time()
         for i, (images, target) in enumerate(val_loader):
-            if args.gpu is not None:
-                images = images.cuda(args.gpu, non_blocking=True)
             if torch.cuda.is_available():
+                images = images.cuda(args.gpu, non_blocking=True)
                 target = target.cuda(args.gpu, non_blocking=True)
 
             # compute output


### PR DESCRIPTION
1. A better condition for single GPU (when your machine has only one GPU)
I found that even if your machine has only one GPU and you don't specify GPU id (e.g. `--gpu 0`), model is passed to `DataParallel`.
So I added a condition so that your model is not parallel even when you don't use `--gpu` option.
```python
elif torch.cuda.device_count() == 1:
        model = model.cuda()
```
2. Removing redundant condition
I fixed conditions about putting torchTensors on CUDA memory. We don't need `if args.gpu is not None` here:
```python 
if args.gpu is not None:
    images = images.cuda(args.gpu, non_blocking=True)
```
According [pytorch document](https://pytorch.org/docs/stable/tensors.html#torch.Tensor.cuda), in `torchTensors.cuda(device=None)` is also acceptable.