### PR TITLE
[WIP] Fix rpc param server example

### DIFF
--- a/distributed/rpc/rnn/main.py
+++ b/distributed/rpc/rnn/main.py
@@ -72,8 +72,8 @@ def run_worker(rank, world_size):
     """
     os.environ['MASTER_ADDR'] = 'localhost'
     os.environ['MASTER_PORT'] = '29500'
-    if rank == 1:
-        rpc.init_rpc("trainer", rank=rank, world_size=world_size)
+    if rank != 0:
+        rpc.init_rpc(f"trainer{rank}", rank=rank, world_size=world_size)
         _run_trainer()
     else:
         rpc.init_rpc("ps", rank=rank, world_size=world_size)
@@ -85,5 +85,5 @@ def run_worker(rank, world_size):
 
 
 if __name__=="__main__":
-    world_size = 2
+    world_size = 3
     mp.spawn(run_worker, args=(world_size, ), nprocs=world_size, join=True)


### PR DESCRIPTION
Open 3 separate terminals and run:
python rpc_parameter_server.py --world_size=3 --rank=0
python rpc_parameter_server.py --world_size=3 --rank=1
python rpc_parameter_server.py --world_size=3 --rank=2

The main issue seems to be that one trainer calls optimizer.step() and updates the weights before the other trainer calls backward, which results in the autograd error. 

This fix makes it so that only one trainer operates on the same model one at a time. I.e. only one trainer does all of fwd, backward, and opt, and only then is the next trainer allowed to do its fwd/backward/opt step. This is done hackily by the trainers waiting for each other with cond vars.

Note: This fix is just for discussion, not intended to be merged. 