### PR TITLE
Convert loaded image to RGB in Fast Neural Style

### DIFF
--- a/fast_neural_style/neural_style/utils.py
+++ b/fast_neural_style/neural_style/utils.py
@@ -3,7 +3,7 @@ from PIL import Image
 
 
 def load_image(filename, size=None, scale=None):
-    img = Image.open(filename)
+    img = Image.open(filename).convert('RGB')
     if size is not None:
         img = img.resize((size, size), Image.ANTIALIAS)
     elif scale is not None:


### PR DESCRIPTION
Convert loaded image to RGB to avoid size mismatch for an RGBA image

```python 
img = Image.open(filename).convert('RGB')
```