### PR TITLE
support ddp example on Windows

### DIFF
--- a/distributed/ddp/README.md
+++ b/distributed/ddp/README.md
@@ -143,8 +143,7 @@ def demo_basic(local_world_size, local_rank):
     optimizer.step()
 ```
 
-The application can be launched via `launch.py` as follows on a 8 GPU node with one process per GPU: 
-Note: So far, we only support filestore on windows. Please make sure the default directory c:\tmp exists or change the filepath in the code.
+The application can be launched via `launch.py` as follows on a 8 GPU node with one process per GPU:
 ```sh
 python /path/to/launch.py --nnode=1 --node_rank=0 --nproc_per_node=8 example.py --local_world_size=8
 ```

--- a/distributed/ddp/README.md
+++ b/distributed/ddp/README.md
@@ -143,7 +143,8 @@ def demo_basic(local_world_size, local_rank):
     optimizer.step()
 ```
 
-The application can be launched via `launch.py` as follows on a 8 GPU node with one process per GPU:
+The application can be launched via `launch.py` as follows on a 8 GPU node with one process per GPU: 
+Note: So far, we only support filestore on windows. Please make sure the default directory c:\tmp exists or change the filepath in the code.
 ```sh
 python /path/to/launch.py --nnode=1 --node_rank=0 --nproc_per_node=8 example.py --local_world_size=8
 ```

--- a/distributed/ddp/example.py
+++ b/distributed/ddp/example.py
@@ -48,12 +48,6 @@ def demo_basic(local_world_size, local_rank):
 
 
 def spmd_main(local_world_size, local_rank):
-    # These are the parameters used to initialize the process group
-    env_dict = {
-        key: os.environ[key]
-        for key in ("MASTER_ADDR", "MASTER_PORT", "RANK", "WORLD_SIZE")
-    }
-    print(f"[{os.getpid()}] Initializing process group with: {env_dict}")
     
     if sys.platform == "win32":
         # Distributed package only covers collective communications with Gloo
@@ -62,11 +56,17 @@ def spmd_main(local_world_size, local_rank):
         init_method = "file:///c:/tmp/tmp_filestore"
         dist.init_process_group(backend="gloo", init_method=init_method, rank=local_rank, world_size=local_world_size)
     else:
+        # These are the parameters used to initialize the process group
+        env_dict = {
+            key: os.environ[key]
+            for key in ("MASTER_ADDR", "MASTER_PORT", "RANK", "WORLD_SIZE")
+        }
+        print(f"[{os.getpid()}] Initializing process group with: {env_dict}")        
         dist.init_process_group(backend="nccl")
 
     print(
         f"[{os.getpid()}]: world_size = {dist.get_world_size()}, "
-        + f"rank = {dist.get_rank()}, backend={dist.get_backend()}"
+        + f"rank = {dist.get_rank()}, backend={dist.get_backend()} \n"
     )
 
     demo_basic(local_world_size, local_rank)

--- a/distributed/ddp/example.py
+++ b/distributed/ddp/example.py
@@ -60,9 +60,6 @@ def spmd_main(local_world_size, local_rank):
         # backend and FileStore on Windows platform. Set init_method parameter
         # in init_process_group to a local file.
         init_method = "file:///c:/tmp/tmp_filestore"
-        if not os.path.exists("c:/tmp"):
-            print("Directory not exist for filestore.")
-            return
         dist.init_process_group(backend="gloo", init_method=init_method, rank=local_rank, world_size=local_world_size)
     else:
         dist.init_process_group(backend="nccl")

--- a/distributed/ddp/example.py
+++ b/distributed/ddp/example.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import tempfile
 import sys
 
 import torch
@@ -53,7 +54,8 @@ def spmd_main(local_world_size, local_rank):
         # Distributed package only covers collective communications with Gloo
         # backend and FileStore on Windows platform. Set init_method parameter
         # in init_process_group to a local file.
-        init_method = "file:///c:/tmp/tmp_filestore"
+        temp_dir = tempfile.gettempdir()
+        init_method = "file:///" + os.path.join(temp_dir, "ddp_example")
         dist.init_process_group(backend="gloo", init_method=init_method, rank=local_rank, world_size=local_world_size)
     else:
         # These are the parameters used to initialize the process group

--- a/distributed/ddp/example.py
+++ b/distributed/ddp/example.py
@@ -32,7 +32,7 @@ def demo_basic(local_world_size, local_rank):
 
     print(
         f"[{os.getpid()}] rank = {dist.get_rank()}, "
-        + f"world_size = {dist.get_world_size()}, n = {n}, device_ids = {device_ids}"
+        + f"world_size = {dist.get_world_size()}, n = {n}, device_ids = {device_ids} \n", end=''
     )
 
     model = ToyModel().cuda(device_ids[0])
@@ -69,7 +69,7 @@ def spmd_main(local_world_size, local_rank):
         else:
             # It is a example application, For convience, we create a file in temp dir.
             temp_dir = tempfile.gettempdir()
-            init_method = "file:///" + os.path.join(temp_dir, "ddp_example")
+            init_method = f"file:///{os.path.join(temp_dir, 'ddp_example')}"
         dist.init_process_group(backend="gloo", init_method=init_method, rank=int(env_dict["RANK"]), world_size=int(env_dict["WORLD_SIZE"]))
     else:
         print(f"[{os.getpid()}] Initializing process group with: {env_dict}")  
@@ -77,7 +77,7 @@ def spmd_main(local_world_size, local_rank):
 
     print(
         f"[{os.getpid()}]: world_size = {dist.get_world_size()}, "
-        + f"rank = {dist.get_rank()}, backend={dist.get_backend()} \n"
+        + f"rank = {dist.get_rank()}, backend={dist.get_backend()} \n", end=''
     )
 
     demo_basic(local_world_size, local_rank)


### PR DESCRIPTION
The change can help users run ddp example on Windows directly.
So far, only gloo and filestore are supported on Windows