### PR TITLE
[fix] Rewrite typo in the Readme of cpp-regression

### DIFF
--- a/cpp/regression/README.md
+++ b/cpp/regression/README.md
@@ -5,7 +5,7 @@ Trains a single fully-connected layer to fit a 4th degree polynomial.
 To build the code, run the following commands from your terminal:
 
 ```shell
-$ cd mnist
+$ cd regression
 $ mkdir build
 $ cd build
 $ cmake -DCMAKE_PREFIX_PATH=/path/to/libtorch ..


### PR DESCRIPTION
I found a typo error in **examples/cpp/regression/README.md**.

`cd mnist` => `cd regression`

It's a little difference, but important.

Thank you for GOOD EXAMPLES :)
