### PR TITLE
[fix] wrong file extention in cpp-dcgan-README

### DIFF
--- a/cpp/dcgan/README.md
+++ b/cpp/dcgan/README.md
@@ -51,6 +51,6 @@ The training script periodically generates image samples. Use the
 For example:
 
 ```shell
-$ python display_samples.py -i dcgan-sample-10.png
+$ python display_samples.py -i dcgan-sample-10.pt
 Saved out.png
 ```


### PR DESCRIPTION
I rewrote the wrong extension.

dcgan-sample-10.**png** => dcgan-sample-10.**pt**

thank you.
