### PR TITLE
updating onnx implementation

### DIFF
--- a/fast_neural_style/neural_style/neural_style.py
+++ b/fast_neural_style/neural_style/neural_style.py
@@ -153,25 +153,6 @@ def stylize(args):
     utils.save_image(args.output_image, output[0])
 
 
-def stylize_onnx_caffe2(content_image, args):
-    """
-    Read ONNX model and run it using Caffe2
-    """
-
-    assert not args.export_onnx
-
-    import onnx
-    import onnx_caffe2.backend
-
-    model = onnx.load(args.model)
-
-    prepared_backend = onnx_caffe2.backend.prepare(model, device='CUDA' if args.cuda else 'CPU')
-    inp = {model.graph.input[0].name: content_image.numpy()}
-    c2_out = prepared_backend.run(inp)[0]
-
-    return torch.from_numpy(c2_out)
-
-
 def stylize_onnx(content_image, args):
     """
     Read ONNX model and run it using onnxruntime


### PR DESCRIPTION
The old onnx implementations seemed to be outdated and didn't properly work for me.
I set the model to evaluation mode before transforming to onnx, I set the onnx opset_version to 11 (below there was a warning).
By running the onnx model I got the warning, that  onnx_caffe2.backend only supports opset_version 2.
Therefore I followed the tutorial: https://pytorch.org/tutorials/advanced/super_resolution_with_onnxruntime.html to run the onnx model with onnxruntime instead.

I wasn't sure if I should leave the old function in the file with an option to run it, but I deleted to keep the file clean.