### PR TITLE
Minor spelling correction

### DIFF
--- a/distributed/ddp/README.md
+++ b/distributed/ddp/README.md
@@ -14,7 +14,7 @@ in a _data parallel_ fashion: multiple workers train the same global
 model by processing different portions of a large dataset, computing
 local gradients (aka _sub_-gradients) independently and then
 collectively synchronizing gradients using the AllReduce primitive. In
-HPC terminology, this model of execution is called _Single Program
+HPC terminology, this mode of execution is called _Single Program
 Multiple Data_ or SPMD since the same application runs on all
 application but each one operates on different portions of the
 training dataset.


### PR DESCRIPTION
I made a minor spelling correction that I found while reading [Launching and configuring distributed data parallel applications](https://github.com/pytorch/examples/blob/master/distributed/ddp/README.md).