### PR TITLE
Fix comment to use zero-indexed ranks

### DIFF
--- a/distributed/ddp/example.py
+++ b/distributed/ddp/example.py
@@ -25,8 +25,8 @@ class ToyModel(nn.Module):
 def demo_basic(local_world_size, local_rank):
 
     # setup devices for this process. For local_world_size = 2, num_gpus = 8,
-    # rank 1 uses GPUs [0, 1, 2, 3] and
-    # rank 2 uses GPUs [4, 5, 6, 7].
+    # rank 0 uses GPUs [0, 1, 2, 3] and
+    # rank 1 uses GPUs [4, 5, 6, 7].
     n = torch.cuda.device_count() // local_world_size
     device_ids = list(range(local_rank * n, (local_rank + 1) * n))
 


### PR DESCRIPTION
The tutorial otherwise uses zero-indexed ranks throughout, so this change makes the example mentioned in the comment in `demo_basic()` follow the same convention.

No testing was performed since this only edits comments.