### PR TITLE
Fix comment to use zero-indexed ranks

### DIFF
--- a/distributed/ddp/README.md
+++ b/distributed/ddp/README.md
@@ -120,8 +120,8 @@ Given the local rank and world size, the training function, `demo_basic` initial
 def demo_basic(local_world_size, local_rank):
 
     # setup devices for this process. For local_world_size = 2, num_gpus = 8,
-    # rank 1 uses GPUs [0, 1, 2, 3] and
-    # rank 2 uses GPUs [4, 5, 6, 7].
+    # rank 0 uses GPUs [0, 1, 2, 3] and
+    # rank 1 uses GPUs [4, 5, 6, 7].
     n = torch.cuda.device_count() // local_world_size
     device_ids = list(range(local_rank * n, (local_rank + 1) * n))
 


### PR DESCRIPTION
This is a follow-up to the PR: https://github.com/pytorch/examples/pull/916

I inadvertently did not update the comment in the `README.md` file as well. The justification is the same: The tutorial otherwise uses zero-indexed ranks throughout, so this change makes the example mentioned in the comment in demo_basic() follow the same convention.