### PR TITLE
 word_language_model/generate.py reads a model file trained with CUDA, into CPU if CUDA is not available.

### DIFF
--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -44,7 +44,7 @@ if args.temperature < 1e-3:
     parser.error("--temperature has to be greater or equal 1e-3")
 
 with open(args.checkpoint, 'rb') as f:
-    model = torch.load(f).to(device)
+    model = torch.load(f, map_location=device)
 model.eval()
 
 corpus = data.Corpus(args.data)


### PR DESCRIPTION
`word_language_model/generate.py` fails to use a model file trained with CUDA on a machine without CUDA.

### Repro steps:

- run `cd word_language_model && python main.py` on a machine with CUDA.
- copy `model.pt` to a machine without CUDA.
- run `cd word_language_model && python generate.py` on a machine without CUDA.

It shows
```
Traceback (most recent call last):
  File "generate.py", line 47, in <module>
    model = torch.load(f).to(device)
  File "/home/kaiida/anaconda3/envs/py38/lib/python3.8/site-packages/torch/serialization.py", line 607, in load
    return _load(opened_zipfile, map_location, pickle_module, **pickle_load_args)
  File "/home/kaiida/anaconda3/envs/py38/lib/python3.8/site-packages/torch/serialization.py", line 882, in _load
    result = unpickler.load()
  File "/home/kaiida/anaconda3/envs/py38/lib/python3.8/site-packages/torch/serialization.py", line 857, in persistent_load
    load_tensor(data_type, size, key, _maybe_decode_ascii(location))
  File "/home/kaiida/anaconda3/envs/py38/lib/python3.8/site-packages/torch/serialization.py", line 846, in load_tensor
    loaded_storages[key] = restore_location(storage, location)
  File "/home/kaiida/anaconda3/envs/py38/lib/python3.8/site-packages/torch/serialization.py", line 175, in default_restore_location
    result = fn(storage, location)
  File "/home/kaiida/anaconda3/envs/py38/lib/python3.8/site-packages/torch/serialization.py", line 151, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "/home/kaiida/anaconda3/envs/py38/lib/python3.8/site-packages/torch/serialization.py", line 135, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```

### Fix:

use `torch.load(f, map_location=device)` to load saved variables in CUDA into the target device instead of casting with `to()`.