### PR TITLE
change torchtext to torchtext.legacy

### DIFF
--- a/snli/train.py
+++ b/snli/train.py
@@ -6,8 +6,8 @@ import torch
 import torch.optim as O
 import torch.nn as nn
 
-from torchtext import data
-from torchtext import datasets
+from torchtext.legacy import data
+from torchtext.legacy import datasets
 
 from model import SNLIClassifier
 from util import get_args, makedirs


### PR DESCRIPTION
proposed fix for #942

According to Torchtext 0.9.0 release note:
- torchtext.data.Field -> torchtext.legacy.data.Field
- torchtext.data.Dataset -> torchtext.legacy.data.Dataset

https://github.com/pytorch/text/releases/tag/v0.9.0-rc5