### PR TITLE
Updating retracing examples to handle n-ary operators

### DIFF
--- a/fx/inline_function.py
+++ b/fx/inline_function.py
@@ -40,10 +40,11 @@ class M(torch.nn.Module):
 # represented as a `call_module` Node. The full operation in the
 # generated `forward` function's code will appear as `self.relu(x)`
 m = symbolic_trace(M())
-tracer = torch.fx.proxy.GraphAppendingTracer(m.graph)
 
 # Insert nodes from the ReLU graph in place of the original call to
 # `self.relu`
+# create a graph-appending tracer pointing to the original graph
+tracer = torch.fx.proxy.GraphAppendingTracer(m.graph)
 for node in m.graph.nodes:
     # Find `call_module` Node in `m` that corresponds to `self.relu`.
     # This is the Node we want to swap out for an inlined version of the

--- a/fx/proxy_based_graph_creation.py
+++ b/fx/proxy_based_graph_creation.py
@@ -32,19 +32,28 @@ empty ``nn.Module`` class.
 
 # Create a graph independently of symbolic tracing
 graph = Graph()
+tracer = torch.fx.proxy.GraphAppendingTracer(graph)
 
 # Create raw Nodes
 raw1 = graph.placeholder('x')
 raw2 = graph.placeholder('y')
 
-# Initialize Proxies using the raw Nodes
-y = Proxy(raw1)
-z = Proxy(raw2)
+# Initialize Proxies using the raw Nodes and graph's default tracer
+y = Proxy(raw1, tracer)
+z = Proxy(raw2, tracer)
+# y = Proxy(raw1)
+# z = Proxy(raw2)
 
 # Create other operations using the Proxies `y` and `z`
 a = torch.cat([y, z])
 b = torch.tanh(a)
 c = torch.neg(b)
+# By using the graph's own appending tracer to create Proxies,
+# notice we can now use n-ary operators on operations without
+# multiple tracers being created at run-time (line 52) which leads
+# to errors # To try this out for yourself, replace lines 42, 43
+# with 44, 45
+z = torch.add(b, c)
 
 # Create a new output Node and add it to the Graph. By doing this, the
 # Graph will contain all the Nodes we just created (since they're all


### PR DESCRIPTION
Summary:
Replaced Proxy(object) creations with Proxy(object, GraphAppendingTracer)
which ensures graceful handling of n-ary operators.

By default Proxy creates a new tracer when no tracer arg
is provided, these examples encourage use of Proxy creation
with the GraphAppendingTracer when dealing with n-ary operators.

Implements cases outlined in pytorch/pytorch#68195

Test Plan:
```bash
python fx/inline_function.py
python fx/proxy_based_graph_creation.py
python fx/primitive_library.py
```

No errors on the above and output of `fx/primitive_library` confirmed
to be the same as inline commented expected output. Also verified  via
diff of OG output and updated output.

FYI: `fx/nnc_compile.py` might need this fix too, but I was not able to run
the script at all. Threw the following error:
`AttributeError: module 'torch._C._te' has no attribute 'KernelScope'`

Reviewers:
jamesreed
qianxuqx

Subscribers:

Tasks:
T105739531

Tags:
