### PR TITLE
#71844 Migrate default branch to main.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,13 +2,13 @@ name: Run Examples
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     # Every day at 3:00am
     - cron: '0 3 * * *'
-        
+
 
 jobs:
   test:
@@ -39,4 +39,3 @@ jobs:
         title: Daily CI failed
         body:  Commit ${{ github.sha }} daily scheduled [CI run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) failed, please check why
         assignees: ''
-

--- a/distributed/rpc/batch/reinforce.py
+++ b/distributed/rpc/batch/reinforce.py
@@ -35,7 +35,7 @@ class Policy(nn.Module):
     r"""
     Borrowing the ``Policy`` class from the Reinforcement Learning example.
     Copying the code to make these two examples independent.
-    See https://github.com/pytorch/examples/tree/master/reinforcement_learning
+    See https://github.com/pytorch/examples/tree/main/reinforcement_learning
     """
     def __init__(self, batch=True):
         super(Policy, self).__init__()

--- a/distributed/rpc/rl/main.py
+++ b/distributed/rpc/rl/main.py
@@ -51,7 +51,7 @@ class Policy(nn.Module):
     r"""
     Borrowing the ``Policy`` class from the Reinforcement Learning example.
     Copying the code to make these two examples independent.
-    See https://github.com/pytorch/examples/tree/master/reinforcement_learning
+    See https://github.com/pytorch/examples/tree/main/reinforcement_learning
     """
     def __init__(self):
         super(Policy, self).__init__()
@@ -129,7 +129,7 @@ class Agent:
     def select_action(self, ob_id, state):
         r"""
         This function is mostly borrowed from the Reinforcement Learning example.
-        See https://github.com/pytorch/examples/tree/master/reinforcement_learning
+        See https://github.com/pytorch/examples/tree/main/reinforcement_learning
         The main difference is that instead of keeping all probs in one list,
         the agent keeps probs in a dictionary, one key per observer.
 
@@ -171,7 +171,7 @@ class Agent:
     def finish_episode(self):
         r"""
         This function is mostly borrowed from the Reinforcement Learning example.
-        See https://github.com/pytorch/examples/tree/master/reinforcement_learning
+        See https://github.com/pytorch/examples/tree/main/reinforcement_learning
         The main difference is that it joins all probs and rewards from
         different observers into one list, and uses the minimum observer rewards
         as the reward of the current episode.

--- a/distributed/rpc/rnn/rnn.py
+++ b/distributed/rpc/rnn/rnn.py
@@ -73,7 +73,7 @@ class RNNModel(nn.Module):
     A distributed RNN model which puts embedding table and decoder parameters on
     a remote parameter server, and locally holds parameters for the LSTM module.
     The structure of the RNN model is borrowed from the word language model
-    example. See https://github.com/pytorch/examples/blob/master/word_language_model/model.py
+    example. See https://github.com/pytorch/examples/blob/main/word_language_model/model.py
     """
     def __init__(self, ps, ntoken, ninp, nhid, nlayers, dropout=0.5):
         super(RNNModel, self).__init__()


### PR DESCRIPTION
This PR includes updates to change the default branch from master to main.

Fixes #71844 from pytorch repo. 