### PR TITLE
Fixed distributed GPU bug in ImageNet example

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -290,9 +290,9 @@ def train(train_loader, model, criterion, optimizer, epoch, args):
         # measure data loading time
         data_time.update(time.time() - end)
 
-        if torch.cuda.is_available():
+        if args.gpu is not None:
             images = images.cuda(args.gpu, non_blocking=True)
-        if torch.cuda.is_available():
+        if args.gpu is not None:
             target = target.cuda(args.gpu, non_blocking=True)
 
         # compute output
@@ -334,9 +334,9 @@ def validate(val_loader, model, criterion, args):
     with torch.no_grad():
         end = time.time()
         for i, (images, target) in enumerate(val_loader):
-            if torch.cuda.is_available():
+            if args.gpu is not None:
                 images = images.cuda(args.gpu, non_blocking=True)
-            if torch.cuda.is_available():
+            if args.gpu is not None:
                 target = target.cuda(args.gpu, non_blocking=True)
 
             # compute output

--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -290,7 +290,7 @@ def train(train_loader, model, criterion, optimizer, epoch, args):
         # measure data loading time
         data_time.update(time.time() - end)
 
-        if args.gpu is not None:
+        if torch.cuda.is_available():
             images = images.cuda(args.gpu, non_blocking=True)
         if torch.cuda.is_available():
             target = target.cuda(args.gpu, non_blocking=True)
@@ -334,7 +334,7 @@ def validate(val_loader, model, criterion, args):
     with torch.no_grad():
         end = time.time()
         for i, (images, target) in enumerate(val_loader):
-            if args.gpu is not None:
+            if torch.cuda.is_available():
                 images = images.cuda(args.gpu, non_blocking=True)
             if torch.cuda.is_available():
                 target = target.cuda(args.gpu, non_blocking=True)


### PR DESCRIPTION
The current imagenet example doesn't move images to the GPU in the distributed GPU case, only in the single GPU case:

https://github.com/pytorch/examples/blob/main/imagenet/main.py#L293
https://github.com/pytorch/examples/blob/main/imagenet/main.py#L337

This leads to errors like the following:

```
RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor) should be the same or input should be a MKLDNN tensor and weight is a dense tensor
```

I think this can be fixed by relaxing the `if` statement.