### PR TITLE
env.seed is deprecated, change to env.reset

### DIFF
--- a/reinforcement_learning/reinforce.py
+++ b/reinforcement_learning/reinforce.py
@@ -23,7 +23,7 @@ args = parser.parse_args()
 
 
 env = gym.make('CartPole-v1')
-env.seed(args.seed)
+env.reset(seed=args.seed)
 torch.manual_seed(args.seed)
 
 


### PR DESCRIPTION
env.seed is deprecated and this PR updates that to env.reset, which gets rid of the warning message.