### PR TITLE
[parameter_server] fix deadlock in multiprocessing by using spawn

### DIFF
--- a/distributed/rpc/parameter_server/rpc_parameter_server.py
+++ b/distributed/rpc/parameter_server/rpc_parameter_server.py
@@ -266,6 +266,11 @@ if __name__ == '__main__':
     os.environ['MASTER_PORT'] = args.master_port
     processes = []
     world_size = args.world_size
+
+    # Note that Linux uses "fork" by default, which may cause deadlock.
+    # Besides, cuda doesn't support "fork" and Windows only supports "spawn"
+    mp.set_start_method("spawn")
+
     if args.rank == 0:
         p = mp.Process(target=run_parameter_server, args=(0, world_size))
         p.start()


### PR DESCRIPTION
Bug fix for https://github.com/pytorch/examples/issues/1023

Tested it in Mac with CPU, in Linux with CPU and 2 GPUs(aws p3.8xlarge instance with Amazon Linux/RHEL).