### PR TITLE
Use Modern Python 3 Syntax and Patterns

### DIFF
--- a/cpp/dcgan/display_samples.py
+++ b/cpp/dcgan/display_samples.py
@@ -1,5 +1,5 @@
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
 
 import argparse
 

--- a/cpp/tools/download_mnist.py
+++ b/cpp/tools/download_mnist.py
@@ -1,5 +1,5 @@
-from __future__ import division
-from __future__ import print_function
+
+
 
 import argparse
 import gzip

--- a/dcgan/main.py
+++ b/dcgan/main.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import argparse
 import os
 import random

--- a/dcgan/main.py
+++ b/dcgan/main.py
@@ -122,7 +122,7 @@ def weights_init(m):
 
 class Generator(nn.Module):
     def __init__(self, ngpu):
-        super(Generator, self).__init__()
+        super().__init__()
         self.ngpu = ngpu
         self.main = nn.Sequential(
             # input is Z, going into a convolution
@@ -164,7 +164,7 @@ print(netG)
 
 class Discriminator(nn.Module):
     def __init__(self, ngpu):
-        super(Discriminator, self).__init__()
+        super().__init__()
         self.ngpu = ngpu
         self.main = nn.Sequential(
             # input is (nc) x 64 x 64

--- a/distributed/ddp/example.py
+++ b/distributed/ddp/example.py
@@ -13,7 +13,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 class ToyModel(nn.Module):
     def __init__(self):
-        super(ToyModel, self).__init__()
+        super().__init__()
         self.net1 = nn.Linear(10, 10)
         self.relu = nn.ReLU()
         self.net2 = nn.Linear(10, 5)

--- a/distributed/ddp/main.py
+++ b/distributed/ddp/main.py
@@ -23,7 +23,7 @@ def cleanup():
 
 class ToyModel(nn.Module):
     def __init__(self):
-        super(ToyModel, self).__init__()
+        super().__init__()
         self.net1 = nn.Linear(10, 10)
         self.relu = nn.ReLU()
         self.net2 = nn.Linear(10, 5)
@@ -103,7 +103,7 @@ def demo_checkpoint(rank, world_size):
 
 class ToyMpModel(nn.Module):
     def __init__(self, dev0, dev1):
-        super(ToyMpModel, self).__init__()
+        super().__init__()
         self.dev0 = dev0
         self.dev1 = dev1
         self.net1 = torch.nn.Linear(10, 10).to(dev0)

--- a/distributed/rpc/batch/reinforce.py
+++ b/distributed/rpc/batch/reinforce.py
@@ -38,7 +38,7 @@ class Policy(nn.Module):
     See https://github.com/pytorch/examples/tree/main/reinforcement_learning
     """
     def __init__(self, batch=True):
-        super(Policy, self).__init__()
+        super().__init__()
         self.affine1 = nn.Linear(4, 128)
         self.dropout = nn.Dropout(p=0.6)
         self.affine2 = nn.Linear(128, 2)

--- a/distributed/rpc/ddp_rpc/main.py
+++ b/distributed/rpc/ddp_rpc/main.py
@@ -25,7 +25,7 @@ class HybridModel(torch.nn.Module):
     """
 
     def __init__(self, remote_emb_module, device):
-        super(HybridModel, self).__init__()
+        super().__init__()
         self.remote_emb_module = remote_emb_module
         self.fc = DDP(torch.nn.Linear(16, 8).cuda(device), device_ids=[device])
         self.device = device

--- a/distributed/rpc/parameter_server/rpc_parameter_server.py
+++ b/distributed/rpc/parameter_server/rpc_parameter_server.py
@@ -17,7 +17,7 @@ from torchvision import datasets, transforms
 
 class Net(nn.Module):
     def __init__(self, num_gpus=0):
-        super(Net, self).__init__()
+        super().__init__()
         print(f"Using {num_gpus} GPUs to train")
         self.num_gpus = num_gpus
         device = torch.device(

--- a/distributed/rpc/pipeline/main.py
+++ b/distributed/rpc/pipeline/main.py
@@ -35,7 +35,7 @@ def conv1x1(in_planes, out_planes, stride=1):
 class ResNetBase(nn.Module):
     def __init__(self, block, inplanes, num_classes=1000,
                  groups=1, width_per_group=64, norm_layer=None):
-        super(ResNetBase, self).__init__()
+        super().__init__()
 
         self._lock = threading.Lock()
         self._block = block
@@ -79,7 +79,7 @@ class ResNetShard1(ResNetBase):
     The first part of ResNet.
     """
     def __init__(self, device, *args, **kwargs):
-        super(ResNetShard1, self).__init__(
+        super().__init__(
             Bottleneck, 64, num_classes=num_classes, *args, **kwargs)
 
         self.device = device
@@ -111,7 +111,7 @@ class ResNetShard2(ResNetBase):
     The second part of ResNet.
     """
     def __init__(self, device, *args, **kwargs):
-        super(ResNetShard2, self).__init__(
+        super().__init__(
             Bottleneck, 512, num_classes=num_classes, *args, **kwargs)
 
         self.device = device
@@ -135,7 +135,7 @@ class DistResNet50(nn.Module):
     Assemble two parts as an nn.Module and define pipelining logic
     """
     def __init__(self, split_size, workers, *args, **kwargs):
-        super(DistResNet50, self).__init__()
+        super().__init__()
 
         self.split_size = split_size
 

--- a/distributed/rpc/rl/main.py
+++ b/distributed/rpc/rl/main.py
@@ -54,7 +54,7 @@ class Policy(nn.Module):
     See https://github.com/pytorch/examples/tree/main/reinforcement_learning
     """
     def __init__(self):
-        super(Policy, self).__init__()
+        super().__init__()
         self.affine1 = nn.Linear(4, 128)
         self.dropout = nn.Dropout(p=0.6)
         self.affine2 = nn.Linear(128, 2)

--- a/distributed/rpc/rnn/rnn.py
+++ b/distributed/rpc/rnn/rnn.py
@@ -40,7 +40,7 @@ class EmbeddingTable(nn.Module):
     Encoding layers of the RNNModel
     """
     def __init__(self, ntoken, ninp, dropout):
-        super(EmbeddingTable, self).__init__()
+        super().__init__()
         self.drop = nn.Dropout(dropout)
         self.encoder = nn.Embedding(ntoken, ninp)
         if torch.cuda.is_available():
@@ -58,7 +58,7 @@ class Decoder(nn.Module):
     Decoding layers of the RNNModel
     """
     def __init__(self, ntoken, nhid, dropout):
-        super(Decoder, self).__init__()
+        super().__init__()
         self.drop = nn.Dropout(dropout)
         self.decoder = nn.Linear(nhid, ntoken)
         nn.init.zeros_(self.decoder.bias)
@@ -76,7 +76,7 @@ class RNNModel(nn.Module):
     example. See https://github.com/pytorch/examples/blob/main/word_language_model/model.py
     """
     def __init__(self, ps, ntoken, ninp, nhid, nlayers, dropout=0.5):
-        super(RNNModel, self).__init__()
+        super().__init__()
 
         # setup embedding table remotely
         self.emb_table_rref = rpc.remote(ps, EmbeddingTable, args=(ntoken, ninp, dropout))

--- a/distributed/sharded_tensor/tensor_parallel.py
+++ b/distributed/sharded_tensor/tensor_parallel.py
@@ -55,7 +55,7 @@ def cleanup():
 
 class ToyModel(nn.Module):
     def __init__(self):
-        super(ToyModel, self).__init__()
+        super().__init__()
         self.net1 = nn.Linear(10, 32)
         self.relu = nn.ReLU()
         self.net2 = nn.Linear(32, 5)

--- a/fast_neural_style/neural_style/transformer_net.py
+++ b/fast_neural_style/neural_style/transformer_net.py
@@ -3,7 +3,7 @@ import torch
 
 class TransformerNet(torch.nn.Module):
     def __init__(self):
-        super(TransformerNet, self).__init__()
+        super().__init__()
         # Initial convolution layers
         self.conv1 = ConvLayer(3, 32, kernel_size=9, stride=1)
         self.in1 = torch.nn.InstanceNorm2d(32, affine=True)
@@ -43,7 +43,7 @@ class TransformerNet(torch.nn.Module):
 
 class ConvLayer(torch.nn.Module):
     def __init__(self, in_channels, out_channels, kernel_size, stride):
-        super(ConvLayer, self).__init__()
+        super().__init__()
         reflection_padding = kernel_size // 2
         self.reflection_pad = torch.nn.ReflectionPad2d(reflection_padding)
         self.conv2d = torch.nn.Conv2d(in_channels, out_channels, kernel_size, stride)
@@ -61,7 +61,7 @@ class ResidualBlock(torch.nn.Module):
     """
 
     def __init__(self, channels):
-        super(ResidualBlock, self).__init__()
+        super().__init__()
         self.conv1 = ConvLayer(channels, channels, kernel_size=3, stride=1)
         self.in1 = torch.nn.InstanceNorm2d(channels, affine=True)
         self.conv2 = ConvLayer(channels, channels, kernel_size=3, stride=1)
@@ -84,7 +84,7 @@ class UpsampleConvLayer(torch.nn.Module):
     """
 
     def __init__(self, in_channels, out_channels, kernel_size, stride, upsample=None):
-        super(UpsampleConvLayer, self).__init__()
+        super().__init__()
         self.upsample = upsample
         reflection_padding = kernel_size // 2
         self.reflection_pad = torch.nn.ReflectionPad2d(reflection_padding)

--- a/fast_neural_style/neural_style/vgg.py
+++ b/fast_neural_style/neural_style/vgg.py
@@ -6,7 +6,7 @@ from torchvision import models
 
 class Vgg16(torch.nn.Module):
     def __init__(self, requires_grad=False):
-        super(Vgg16, self).__init__()
+        super().__init__()
         vgg_pretrained_features = models.vgg16(pretrained=True).features
         self.slice1 = torch.nn.Sequential()
         self.slice2 = torch.nn.Sequential()

--- a/legacy/snli/model.py
+++ b/legacy/snli/model.py
@@ -6,9 +6,9 @@ class Bottle(nn.Module):
 
     def forward(self, input):
         if len(input.size()) <= 2:
-            return super(Bottle, self).forward(input)
+            return super().forward(input)
         size = input.size()[:2]
-        out = super(Bottle, self).forward(input.view(size[0]*size[1], -1))
+        out = super().forward(input.view(size[0]*size[1], -1))
         return out.view(size[0], size[1], -1)
 
 
@@ -19,7 +19,7 @@ class Linear(Bottle, nn.Linear):
 class Encoder(nn.Module):
 
     def __init__(self, config):
-        super(Encoder, self).__init__()
+        super().__init__()
         self.config = config
         input_size = config.d_proj if config.projection else config.d_embed
         dropout = 0 if config.n_layers == 1 else config.dp_ratio
@@ -38,7 +38,7 @@ class Encoder(nn.Module):
 class SNLIClassifier(nn.Module):
 
     def __init__(self, config):
-        super(SNLIClassifier, self).__init__()
+        super().__init__()
         self.config = config
         self.embed = nn.Embedding(config.n_embed, config.d_embed)
         self.projection = Linear(config.d_embed, config.d_proj)

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -10,7 +10,7 @@ from torch.optim.lr_scheduler import StepLR
 
 class Net(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 32, 3, 1)
         self.conv2 = nn.Conv2d(32, 64, 3, 1)
         self.dropout1 = nn.Dropout(0.25)

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import argparse
 import torch
 import torch.nn as nn

--- a/mnist_hogwild/main.py
+++ b/mnist_hogwild/main.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import argparse
 import torch
 import torch.nn as nn

--- a/mnist_hogwild/main.py
+++ b/mnist_hogwild/main.py
@@ -34,7 +34,7 @@ parser.add_argument('--dry-run', action='store_true', default=False,
 
 class Net(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
         self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
         self.conv2_drop = nn.Dropout2d()

--- a/regression/main.py
+++ b/regression/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 from itertools import count
 
 import torch

--- a/reinforcement_learning/actor_critic.py
+++ b/reinforcement_learning/actor_critic.py
@@ -37,7 +37,7 @@ class Policy(nn.Module):
     implements both actor and critic in one model
     """
     def __init__(self):
-        super(Policy, self).__init__()
+        super().__init__()
         self.affine1 = nn.Linear(4, 128)
 
         # actor's layer

--- a/reinforcement_learning/reinforce.py
+++ b/reinforcement_learning/reinforce.py
@@ -29,7 +29,7 @@ torch.manual_seed(args.seed)
 
 class Policy(nn.Module):
     def __init__(self):
-        super(Policy, self).__init__()
+        super().__init__()
         self.affine1 = nn.Linear(4, 128)
         self.dropout = nn.Dropout(p=0.6)
         self.affine2 = nn.Linear(128, 2)

--- a/siamese_network/main.py
+++ b/siamese_network/main.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import argparse, random, copy
 import numpy as np
 

--- a/siamese_network/main.py
+++ b/siamese_network/main.py
@@ -25,7 +25,7 @@ class SiameseNetwork(nn.Module):
         In addition, we aren't using `TripletLoss` as the MNIST dataset is simple, so `BCELoss` can do the trick.
     """
     def __init__(self):
-        super(SiameseNetwork, self).__init__()
+        super().__init__()
         # get resnet model
         self.resnet = torchvision.models.resnet18(pretrained=False)
 
@@ -79,7 +79,7 @@ class SiameseNetwork(nn.Module):
 
 class APP_MATCHER(Dataset):
     def __init__(self, root, train, download=False):
-        super(APP_MATCHER, self).__init__()
+        super().__init__()
 
         # get MNIST dataset
         self.dataset = datasets.MNIST(root, train=train, download=download)

--- a/super_resolution/dataset.py
+++ b/super_resolution/dataset.py
@@ -17,7 +17,7 @@ def load_img(filepath):
 
 class DatasetFromFolder(data.Dataset):
     def __init__(self, image_dir, input_transform=None, target_transform=None):
-        super(DatasetFromFolder, self).__init__()
+        super().__init__()
         self.image_filenames = [join(image_dir, x) for x in listdir(image_dir) if is_image_file(x)]
 
         self.input_transform = input_transform

--- a/super_resolution/main.py
+++ b/super_resolution/main.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import argparse
 from math import log10
 

--- a/super_resolution/model.py
+++ b/super_resolution/model.py
@@ -5,7 +5,7 @@ import torch.nn.init as init
 
 class Net(nn.Module):
     def __init__(self, upscale_factor):
-        super(Net, self).__init__()
+        super().__init__()
 
         self.relu = nn.ReLU()
         self.conv1 = nn.Conv2d(1, 64, (5, 5), (1, 1), (2, 2))

--- a/super_resolution/super_resolve.py
+++ b/super_resolution/super_resolve.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import argparse
 import torch
 from PIL import Image

--- a/time_sequence_prediction/train.py
+++ b/time_sequence_prediction/train.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 
 class Sequence(nn.Module):
     def __init__(self):
-        super(Sequence, self).__init__()
+        super().__init__()
         self.lstm1 = nn.LSTMCell(1, 51)
         self.lstm2 = nn.LSTMCell(51, 51)
         self.linear = nn.Linear(51, 1)

--- a/time_sequence_prediction/train.py
+++ b/time_sequence_prediction/train.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import argparse
 import torch
 import torch.nn as nn

--- a/vae/main.py
+++ b/vae/main.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import argparse
 import torch
 import torch.utils.data

--- a/vae/main.py
+++ b/vae/main.py
@@ -38,7 +38,7 @@ test_loader = torch.utils.data.DataLoader(
 
 class VAE(nn.Module):
     def __init__(self):
-        super(VAE, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(784, 400)
         self.fc21 = nn.Linear(400, 20)

--- a/word_language_model/model.py
+++ b/word_language_model/model.py
@@ -7,7 +7,7 @@ class RNNModel(nn.Module):
     """Container module with an encoder, a recurrent module, and a decoder."""
 
     def __init__(self, rnn_type, ntoken, ninp, nhid, nlayers, dropout=0.5, tie_weights=False):
-        super(RNNModel, self).__init__()
+        super().__init__()
         self.ntoken = ntoken
         self.drop = nn.Dropout(dropout)
         self.encoder = nn.Embedding(ntoken, ninp)
@@ -79,7 +79,7 @@ class PositionalEncoding(nn.Module):
     """
 
     def __init__(self, d_model, dropout=0.1, max_len=5000):
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         self.dropout = nn.Dropout(p=dropout)
 
         pe = torch.zeros(max_len, d_model)
@@ -108,7 +108,7 @@ class TransformerModel(nn.Module):
     """Container module with an encoder, a recurrent or transformer module, and a decoder."""
 
     def __init__(self, ntoken, ninp, nhead, nhid, nlayers, dropout=0.5):
-        super(TransformerModel, self).__init__()
+        super().__init__()
         try:
             from torch.nn import TransformerEncoder, TransformerEncoderLayer
         except:


### PR DESCRIPTION
### Description

Let's use modern style for modern code.

These changes remove python 2 syntax all over the place in favor of modern python 3 syntax first released in 2008.

Commits don't introduce any functionality changes. We're just swapping legacy syntax and practices for modern commonly accepted python practices all over the place.