### PR TITLE
refine imagenet dummy part of #1011

### DIFF
--- a/imagenet/README.md
+++ b/imagenet/README.md
@@ -23,6 +23,14 @@ The default learning rate schedule starts at 0.1 and decays by a factor of 10 ev
 python main.py -a alexnet --lr 0.01 [imagenet-folder with train and val folders]
 ```
 
+## Dummy  Data for Performance Benchmark Only
+
+Due to the data is dummy only for Performance Benchmark, the loss/accuracy is not reliable.
+
+```bash
+python main.py -a resnet18 --dummy
+```
+
 ## Multi-processing Distributed Data Parallel Training
 
 You should always use the NCCL backend for multi-processing distributed training since it currently provides the best distributed training performance.
@@ -49,40 +57,34 @@ python main.py -a resnet50 --dist-url 'tcp://IP_OF_NODE0:FREEPORT' --dist-backen
 
 ## Usage
 
-```
-usage: main.py [-h] [--arch ARCH] [-j N] [--epochs N] [--start-epoch N] [-b N]
-               [--lr LR] [--momentum M] [--weight-decay W] [--print-freq N]
-               [--resume PATH] [-e] [--pretrained] [--world-size WORLD_SIZE]
-               [--rank RANK] [--dist-url DIST_URL]
-               [--dist-backend DIST_BACKEND] [--seed SEED] [--gpu GPU]
-               [--multiprocessing-distributed]
-               DIR
+```bash
+usage: main.py [-h] [-a ARCH] [-j N] [--epochs N] [--start-epoch N] [-b N] [--lr LR] [--momentum M] [--wd W] [-p N] [--resume PATH] [-e] [--pretrained] [--world-size WORLD_SIZE] [--rank RANK]
+               [--dist-url DIST_URL] [--dist-backend DIST_BACKEND] [--seed SEED] [--gpu GPU] [--multiprocessing-distributed] [--dummy]
+               [DIR]
 
 PyTorch ImageNet Training
 
 positional arguments:
-  DIR                   path to dataset
+  DIR                   path to dataset (default: imagenet)
 
 optional arguments:
   -h, --help            show this help message and exit
-  --arch ARCH, -a ARCH  model architecture: alexnet | densenet121 |
-                        densenet161 | densenet169 | densenet201 |
-                        resnet101 | resnet152 | resnet18 | resnet34 |
-                        resnet50 | squeezenet1_0 | squeezenet1_1 | vgg11 |
-                        vgg11_bn | vgg13 | vgg13_bn | vgg16 | vgg16_bn | vgg19
-                        | vgg19_bn (default: resnet18)
+  -a ARCH, --arch ARCH  model architecture: alexnet | convnext_base | convnext_large | convnext_small | convnext_tiny | densenet121 | densenet161 | densenet169 | densenet201 | efficientnet_b0 |
+                        efficientnet_b1 | efficientnet_b2 | efficientnet_b3 | efficientnet_b4 | efficientnet_b5 | efficientnet_b6 | efficientnet_b7 | googlenet | inception_v3 | mnasnet0_5 | mnasnet0_75 |
+                        mnasnet1_0 | mnasnet1_3 | mobilenet_v2 | mobilenet_v3_large | mobilenet_v3_small | regnet_x_16gf | regnet_x_1_6gf | regnet_x_32gf | regnet_x_3_2gf | regnet_x_400mf | regnet_x_800mf |
+                        regnet_x_8gf | regnet_y_128gf | regnet_y_16gf | regnet_y_1_6gf | regnet_y_32gf | regnet_y_3_2gf | regnet_y_400mf | regnet_y_800mf | regnet_y_8gf | resnet101 | resnet152 | resnet18 |
+                        resnet34 | resnet50 | resnext101_32x8d | resnext50_32x4d | shufflenet_v2_x0_5 | shufflenet_v2_x1_0 | shufflenet_v2_x1_5 | shufflenet_v2_x2_0 | squeezenet1_0 | squeezenet1_1 | vgg11 |
+                        vgg11_bn | vgg13 | vgg13_bn | vgg16 | vgg16_bn | vgg19 | vgg19_bn | vit_b_16 | vit_b_32 | vit_l_16 | vit_l_32 | wide_resnet101_2 | wide_resnet50_2 (default: resnet18)
   -j N, --workers N     number of data loading workers (default: 4)
   --epochs N            number of total epochs to run
   --start-epoch N       manual epoch number (useful on restarts)
-  -b N, --batch-size N  mini-batch size (default: 256), this is the total
-                        batch size of all GPUs on the current node when using
-                        Data Parallel or Distributed Data Parallel
+  -b N, --batch-size N  mini-batch size (default: 256), this is the total batch size of all GPUs on the current node when using Data Parallel or Distributed Data Parallel
   --lr LR, --learning-rate LR
                         initial learning rate
   --momentum M          momentum
-  --weight-decay W, --wd W
+  --wd W, --weight-decay W
                         weight decay (default: 1e-4)
-  --print-freq N, -p N  print frequency (default: 10)
+  -p N, --print-freq N  print frequency (default: 10)
   --resume PATH         path to latest checkpoint (default: none)
   -e, --evaluate        evaluate model on validation set
   --pretrained          use pre-trained model
@@ -95,8 +97,8 @@ optional arguments:
   --seed SEED           seed for initializing training.
   --gpu GPU             GPU id to use.
   --multiprocessing-distributed
-                        Use multi-processing distributed training to launch N
-                        processes per node, which has N GPUs. This is the
-                        fastest way to use PyTorch for either single node or
-                        multi node data parallel training
+                        Use multi-processing distributed training to launch N processes per node, which has N GPUs. This is the fastest way to use PyTorch for either single node or multi node data parallel
+                        training
+  --dummy               use fake data to benchmark
+
 ```

--- a/imagenet/README.md
+++ b/imagenet/README.md
@@ -23,9 +23,9 @@ The default learning rate schedule starts at 0.1 and decays by a factor of 10 ev
 python main.py -a alexnet --lr 0.01 [imagenet-folder with train and val folders]
 ```
 
-## Dummy  Data for Performance Benchmark Only
+## Use Dummy Data
 
-Due to the data is dummy only for Performance Benchmark, the loss/accuracy is not reliable.
+ImageNet dataset is large and time-consuming to download. To get started quickly, run `main.py` using dummy data by "--dummy". It's also useful for training speed benchmark. Note that the loss or accuracy is useless in this case.
 
 ```bash
 python main.py -a resnet18 --dummy

--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -26,7 +26,7 @@ model_names = sorted(name for name in models.__dict__
     and callable(models.__dict__[name]))
 
 parser = argparse.ArgumentParser(description='PyTorch ImageNet Training')
-parser.add_argument('data', metavar='DIR', default='imagenet',
+parser.add_argument('data', metavar='DIR', nargs='?', default='imagenet',
                     help='path to dataset (default: imagenet)')
 parser.add_argument('-a', '--arch', metavar='ARCH', default='resnet18',
                     choices=model_names,
@@ -76,6 +76,7 @@ parser.add_argument('--multiprocessing-distributed', action='store_true',
                          'N processes per node, which has N GPUs. This is the '
                          'fastest way to use PyTorch for either single node or '
                          'multi node data parallel training')
+parser.add_argument('--dummy', action='store_true', help="use fake data to benchmark")
 
 best_acc1 = 0
 
@@ -206,28 +207,33 @@ def main_worker(gpu, ngpus_per_node, args):
     cudnn.benchmark = True
 
     # Data loading code
-    traindir = os.path.join(args.data, 'train')
-    valdir = os.path.join(args.data, 'val')
-    normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
+    if args.dummy:
+        print("=> Dummy data is using!")
+        train_dataset = datasets.FakeData(1281167, (3, 224, 224), 1000, transforms.ToTensor())
+        val_dataset = datasets.FakeData(50000, (3, 224, 224), 1000, transforms.ToTensor())
+    else:
+        traindir = os.path.join(args.data, 'train')
+        valdir = os.path.join(args.data, 'val')
+        normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                      std=[0.229, 0.224, 0.225])
 
-    train_dataset = datasets.ImageFolder(
-        traindir,
-        transforms.Compose([
-            transforms.RandomResizedCrop(224),
-            transforms.RandomHorizontalFlip(),
-            transforms.ToTensor(),
-            normalize,
-        ]))
+        train_dataset = datasets.ImageFolder(
+            traindir,
+            transforms.Compose([
+                transforms.RandomResizedCrop(224),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                normalize,
+            ]))
 
-    val_dataset = datasets.ImageFolder(
-        valdir,
-        transforms.Compose([
-            transforms.Resize(256),
-            transforms.CenterCrop(224),
-            transforms.ToTensor(),
-            normalize,
-        ]))
+        val_dataset = datasets.ImageFolder(
+            valdir,
+            transforms.Compose([
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                normalize,
+            ]))
 
     if args.distributed:
         train_sampler = torch.utils.data.distributed.DistributedSampler(train_dataset)

--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -208,7 +208,7 @@ def main_worker(gpu, ngpus_per_node, args):
 
     # Data loading code
     if args.dummy:
-        print("=> Dummy data is using!")
+        print("=> Dummy data is used!")
         train_dataset = datasets.FakeData(1281167, (3, 224, 224), 1000, transforms.ToTensor())
         val_dataset = datasets.FakeData(50000, (3, 224, 224), 1000, transforms.ToTensor())
     else:


### PR DESCRIPTION
we add a method to use dummy data for performance benchmark only, this feature will save a lot of time for downloading real ImageNet Dataset, this is a part of #1011 

![image](https://user-images.githubusercontent.com/22641519/182331135-65d014ce-e959-43fc-b988-323276c6bf7e.png)
 