### PR TITLE
total must be CUDA

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -415,7 +415,7 @@ class AverageMeter(object):
         self.avg = self.sum / self.count
 
     def all_reduce(self):
-        total = torch.FloatTensor([self.sum, self.count])
+        total = torch.FloatTensor([self.sum, self.count]).cuda(self.sum.device)
         dist.all_reduce(total, dist.ReduceOp.SUM, async_op=False)
         self.sum, self.count = total.tolist()
         self.avg = self.sum / self.count


### PR DESCRIPTION
Currently, ``` total ```(https://github.com/pytorch/examples/blob/main/imagenet/main.py#L419) is at cpu but it must be CUDA to compute ``` dist.all_reduce() ```. Otherwise it will raise a ``` RuntimeError: Tensors must be CUDA and dense ```