### PR TITLE
Fix for NCCL backend, all_reduce performed on GPU when available

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -421,7 +421,10 @@ class AverageMeter(object):
         self.avg = self.sum / self.count
 
     def all_reduce(self):
-        total = torch.FloatTensor([self.sum, self.count])
+        if (torch.cuda.is_available()):
+            total = torch.cuda.FloatTensor([self.sum, self.count])
+        else:
+            total = torch.FloatTensor([self.sum, self.count])
         dist.all_reduce(total, dist.ReduceOp.SUM, async_op=False)
         self.sum, self.count = total.tolist()
         self.avg = self.sum / self.count

--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -421,10 +421,8 @@ class AverageMeter(object):
         self.avg = self.sum / self.count
 
     def all_reduce(self):
-        if (torch.cuda.is_available()):
-            total = torch.cuda.FloatTensor([self.sum, self.count])
-        else:
-            total = torch.FloatTensor([self.sum, self.count])
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        total = torch.tensor([self.sum, self.count], dtype=torch.float32, device=device)
         dist.all_reduce(total, dist.ReduceOp.SUM, async_op=False)
         self.sum, self.count = total.tolist()
         self.avg = self.sum / self.count


### PR DESCRIPTION
Use of torch.FloatTensor causes an issue with the NCCL backend, which only supports DistributedDataParallel primitives on GPU. This results in a runtime error "Tensors must be CUDA and dense".

This commit implemented a condition which checks if torch.cuda.is_available() and if so instead uses torch.cuda.FloatTensor to resolve the runtime error for the NCCL backend.