### PR TITLE
Added mps option in generate.py

### DIFF
--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -23,6 +23,8 @@ parser.add_argument('--seed', type=int, default=1111,
                     help='random seed')
 parser.add_argument('--cuda', action='store_true',
                     help='use CUDA')
+parser.add_argument('--mps', action='store_true', default=False,
+                        help='enables macOS GPU training')
 parser.add_argument('--temperature', type=float, default=1.0,
                     help='temperature - higher will increase diversity')
 parser.add_argument('--log-interval', type=int, default=100,
@@ -34,8 +36,17 @@ torch.manual_seed(args.seed)
 if torch.cuda.is_available():
     if not args.cuda:
         print("WARNING: You have a CUDA device, so you should probably run with --cuda.")
-
-device = torch.device("cuda" if args.cuda else "cpu")
+if torch.backends.mps.is_available():
+    if not args.mps:
+        print("WARNING: You have mps device, to enable macOS GPU run with --mps.")
+        
+use_mps = args.mps and torch.backends.mps.is_available()
+if args.cuda:
+    device = torch.device("cuda")
+elif use_mps:
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
 
 if args.temperature < 1e-3:
     parser.error("--temperature has to be greater or equal 1e-3.")


### PR DESCRIPTION
After training a model in Mac with mps option, when trying to run the generate script it is giving a Runtime error "Placeholder storage has not been allocated on MPS device". To avoid this issue, this change is made