### PR TITLE
Fix device mismatch issue in #1071

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -318,8 +318,8 @@ def train(train_loader, model, criterion, optimizer, epoch, device, args):
         data_time.update(time.time() - end)
 
         # move data to the same device as model
-        images = images.to(device)
-        target = target.to(device)
+        images = images.to(device, non_blocking=True)
+        target = target.to(device, non_blocking=True)
 
         # compute output
         output = model(images)

--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -7,18 +7,18 @@ import warnings
 from enum import Enum
 
 import torch
-import torch.nn as nn
-import torch.nn.parallel
 import torch.backends.cudnn as cudnn
 import torch.distributed as dist
-import torch.optim
-from torch.optim.lr_scheduler import StepLR
 import torch.multiprocessing as mp
+import torch.nn as nn
+import torch.nn.parallel
+import torch.optim
 import torch.utils.data
 import torch.utils.data.distributed
-import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 import torchvision.models as models
+import torchvision.transforms as transforms
+from torch.optim.lr_scheduler import StepLR
 from torch.utils.data import Subset
 
 model_names = sorted(name for name in models.__dict__
@@ -275,13 +275,12 @@ def main_worker(gpu, ngpus_per_node, args):
             train_sampler.set_epoch(epoch)
 
         # train for one epoch
-        train(train_loader, model, criterion, optimizer, epoch, args)
+        train(train_loader, model, criterion, optimizer, epoch, device, args)
 
         # evaluate on validation set
         acc1 = validate(val_loader, model, criterion, args)
         
         scheduler.step()
-
         
         # remember best acc@1 and save checkpoint
         is_best = acc1 > best_acc1
@@ -299,7 +298,7 @@ def main_worker(gpu, ngpus_per_node, args):
             }, is_best)
 
 
-def train(train_loader, model, criterion, optimizer, epoch, args):
+def train(train_loader, model, criterion, optimizer, epoch, device, args):
     batch_time = AverageMeter('Time', ':6.3f')
     data_time = AverageMeter('Data', ':6.3f')
     losses = AverageMeter('Loss', ':.4e')
@@ -318,13 +317,9 @@ def train(train_loader, model, criterion, optimizer, epoch, args):
         # measure data loading time
         data_time.update(time.time() - end)
 
-        if args.gpu is not None and torch.cuda.is_available():
-            images = images.cuda(args.gpu, non_blocking=True)
-        elif not args.gpu and torch.cuda.is_available():
-            target = target.cuda(args.gpu, non_blocking=True)
-        elif torch.backends.mps.is_available():
-            images = images.to('mps')
-            target = target.to('mps')
+        # move data to the same device as model
+        images = images.to(device)
+        target = target.to(device)
 
         # compute output
         output = model(images)


### PR DESCRIPTION
It's due to `image` and `model` are in GPU but `target` is still in CPU. As the device is already determined in main(), we don't have to do it again in train(). We can pass device to train() and move data to the same device as model.

## Test plan:
```
python main.py -a resnet50 --dist-url tcp://127.0.0.1:1234 --dist-backend nccl --multiprocessing-distributed --world-size 1 --rank 0 --epochs 3 --batch-size 256 -j64 --dummy
```

<img width="1051" alt="image" src="https://user-images.githubusercontent.com/3350366/193139012-c94a965f-187f-4d0e-a84f-7da383e838d3.png">

