### PR TITLE
Speed-up to O(1) from O(N)  of the computation of each return in REINFORCE  

### DIFF
--- a/reinforcement_learning/reinforce.py
+++ b/reinforcement_learning/reinforce.py
@@ -2,7 +2,7 @@ import argparse
 import gym
 import numpy as np
 from itertools import count
-
+from collections import deque
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -62,10 +62,10 @@ def select_action(state):
 def finish_episode():
     R = 0
     policy_loss = []
-    returns = []
+    returns = deque()
     for r in policy.rewards[::-1]:
         R = r + args.gamma * R
-        returns.insert(0, R)
+        returns.appendleft(R)
     returns = torch.tensor(returns)
     returns = (returns - returns.mean()) / (returns.std() + eps)
     for log_prob, R in zip(policy.saved_log_probs, returns):


### PR DESCRIPTION
### Fix
The function finish_episode() in the reinforce.py script computes returns by insertion at the beginning of a list.
This is an expensive computation in python as shown by the official docs, since it requires O(N) time to shift all its successor elements. 
The same can be achieved but with O(1) time complexity with the python deque data structure, natively supported by python.
To verify the above claims, i tested insertion of 100k elements at the beginning of a list and a deque.
The results are:
- list insertion at the beginning -> 1 second
- deque insertion at the beginning -> 0.004 seconds

### Result
Hence, this is a 250 x speed-up, which becomes relevant when the number of episodes becomes large, as this computation is done at the end of every episode.

Python docs Reference: https://docs.python.org/3/tutorial/datastructures.html#using-lists-as-queues

### Test
As per the contribution guidelines, the following tests have been run and successfully completed.
./run_python_examples.sh "install_deps,reinforcement_learning,clean"

