### PR TITLE
[fix CI] replace assert_allclose with assert_close

### DIFF
--- a/fx/wrap_output_dynamically.py
+++ b/fx/wrap_output_dynamically.py
@@ -1,8 +1,8 @@
 
-import torch
-from torch.fx import Proxy, GraphModule, Node, symbolic_trace
-
 from enum import Enum, auto
+
+import torch
+from torch.fx import GraphModule, Node, Proxy, symbolic_trace
 
 '''
 Wrap Graph Output Dynamically
@@ -82,4 +82,4 @@ orig_output = traced(x, y)
 wrap_in_activation_function(traced, ActivationFunction.LEAKY_RELU)
 new_output = traced(x, y)
 
-torch.testing.assert_allclose(new_output, torch.nn.LeakyReLU()(orig_output))
+torch.testing.assert_close(new_output, torch.nn.LeakyReLU()(orig_output))


### PR DESCRIPTION
CI is broken(https://github.com/pytorch/examples/issues/1087) due to `assert_allclose` is removed in PyTorch, we should replace it with assert_close()

Test plan:
<img width="767" alt="image" src="https://user-images.githubusercontent.com/3350366/200061394-10b96487-ca4e-498b-b6af-94ba04e38fa0.png">
