### PR TITLE
Remove unused code from /cpp/transfer-learning/classify.cpp

### DIFF
--- a/cpp/transfer-learning/classify.cpp
+++ b/cpp/transfer-learning/classify.cpp
@@ -72,9 +72,6 @@ int main(int arc, char** argv)
     // You can also use: auto model = torch::jit::load(model_path);
     torch::jit::script::Module model = torch::jit::load(model_path);
     
-    torch::nn::Linear model_linear(512, 2);
-    torch::load(model_linear, model_path_linear);
-    
     // Print probabilities for dog and cat classes
     print_probabilities(location, model_path, model_path_linear);
     return 0;


### PR DESCRIPTION
**Why**
Lineanr model `model_linear` is loaded in function `print_probabilities`. So line 75 and line 76 can be removed.