### PR TITLE
word language model on Jetson NX

### DIFF
--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -58,7 +58,7 @@ torch.manual_seed(args.seed)
 if torch.cuda.is_available():
     if not args.cuda:
         print("WARNING: You have a CUDA device, so you should probably run with --cuda.")
-if ('mps' in dir(torch.backends)) and torch.backends.mps.is_available():
+if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
     if not args.mps:
         print("WARNING: You have mps device, to enable macOS GPU run with --mps.")
 

--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -58,7 +58,7 @@ torch.manual_seed(args.seed)
 if torch.cuda.is_available():
     if not args.cuda:
         print("WARNING: You have a CUDA device, so you should probably run with --cuda.")
-if torch.backends.mps.is_available():
+if ('mps' in dir(torch.backends)) and torch.backends.mps.is_available():
     if not args.mps:
         print("WARNING: You have mps device, to enable macOS GPU run with --mps.")
 


### PR DESCRIPTION
When running the word language model on Jetson NX, the original main.py fails caused by that torch (NVIDIA offical pytorch docker image: `l4t-pytorch:r35.1.0-pth1.11-py3`) do not have the `mps` backend. This modification has fixed the problem.