### PR TITLE
set type of batch_size argument to int in ddp-tutorial-series

### DIFF
--- a/distributed/ddp-tutorial-series/multigpu.py
+++ b/distributed/ddp-tutorial-series/multigpu.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='simple distributed training job')
     parser.add_argument('total_epochs', type=int, help='Total epochs to train the model')
     parser.add_argument('save_every', type=int, help='How often to save a snapshot')
-    parser.add_argument('--batch_size', default=32, help='Input batch size on each device (default: 32)')
+    parser.add_argument('--batch_size', default=32, type=int, help='Input batch size on each device (default: 32)')
     args = parser.parse_args()
     
     world_size = torch.cuda.device_count()

--- a/distributed/ddp-tutorial-series/multigpu_torchrun.py
+++ b/distributed/ddp-tutorial-series/multigpu_torchrun.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='simple distributed training job')
     parser.add_argument('total_epochs', type=int, help='Total epochs to train the model')
     parser.add_argument('save_every', type=int, help='How often to save a snapshot')
-    parser.add_argument('--batch_size', default=32, help='Input batch size on each device (default: 32)')
+    parser.add_argument('--batch_size', default=32, type=int, help='Input batch size on each device (default: 32)')
     args = parser.parse_args()
     
     main(args.save_every, args.total_epochs, args.batch_size)

--- a/distributed/ddp-tutorial-series/multinode.py
+++ b/distributed/ddp-tutorial-series/multinode.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='simple distributed training job')
     parser.add_argument('total_epochs', type=int, help='Total epochs to train the model')
     parser.add_argument('save_every', type=int, help='How often to save a snapshot')
-    parser.add_argument('--batch_size', default=32, help='Input batch size on each device (default: 32)')
+    parser.add_argument('--batch_size', default=32, type=int, help='Input batch size on each device (default: 32)')
     args = parser.parse_args()
     
     main(args.save_every, args.total_epochs, args.batch_size)

--- a/distributed/ddp-tutorial-series/single_gpu.py
+++ b/distributed/ddp-tutorial-series/single_gpu.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='simple distributed training job')
     parser.add_argument('total_epochs', type=int, help='Total epochs to train the model')
     parser.add_argument('save_every', type=int, help='How often to save a snapshot')
-    parser.add_argument('--batch_size', default=32, help='Input batch size on each device (default: 32)')
+    parser.add_argument('--batch_size', default=32, type=int, help='Input batch size on each device (default: 32)')
     args = parser.parse_args()
     
     device = 0  # shorthand for cuda:0


### PR DESCRIPTION
This corrects a minor bug in the `distributed/ddp-tutorial-series` scripts where explicitly setting the batch size via `--batch_size` throws a `ValueError`.  

## Bug

Running,

```
cd distributed/ddp-tutorial-series
python single_gpu.py --batch_size 32 1 1
```

Produces the following error:

```
Traceback (most recent call last):
  File "/local/scratch/3162385/examples/distributed/ddp-tutorial-series/single_gpu.py", line 82, in <module>
    main(device, args.total_epochs, args.save_every, args.batch_size)
  File "/local/scratch/3162385/examples/distributed/ddp-tutorial-series/single_gpu.py", line 68, in main
    train_data = prepare_dataloader(dataset, batch_size)
  File "/local/scratch/3162385/examples/distributed/ddp-tutorial-series/single_gpu.py", line 58, in prepare_dataloader
    return DataLoader(
  File "/local/scratch/3162385/env/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 350, in __init__
    batch_sampler = BatchSampler(sampler, batch_size, drop_last)
  File "/local/scratch/3162385/env/lib/python3.10/site-packages/torch/utils/data/sampler.py", line 232, in __init__
    raise ValueError("batch_size should be a positive integer value, "
ValueError: batch_size should be a positive integer value, but got batch_size=32
```

## Fix

- Explicitly set the type of the `batch_size` argument to integer:   `parser.add_argument('--batch_size', default=32, type=int, help='Input batch size on each device (default: 32)')`