### PR TITLE
Remove reference to non-existing `--model` argument

### DIFF
--- a/word_language_model/README.md
+++ b/word_language_model/README.md
@@ -10,9 +10,7 @@ python main.py --cuda --tied               # Train a tied LSTM on Wikitext-2 wit
 python main.py --cuda --epochs 6 --model Transformer --lr 5
                                            # Train a Transformer model on Wikitext-2 with CUDA.
 
-python generate.py                         # Generate samples from the trained LSTM model.
-python generate.py --cuda --model Transformer
-                                           # Generate samples from the trained Transformer model.
+python generate.py                         # Generate samples from the default model checkpoint.
 ```
 
 The model uses the `nn.RNN` module (and its sister modules `nn.GRU` and `nn.LSTM`) or Transformer module (`nn.TransformerEncoder` and `nn.TransformerEncoderLayer`) which will automatically use the cuDNN backend if run on CUDA with cuDNN installed.


### PR DESCRIPTION
`generate.py` does not accept a `--model` argument, it just uses the default checkpoint (unless you specify `--checkpoint` argument).