### PR TITLE
fix: fixed local device name in multinode example.

### DIFF
--- a/distributed/ddp-tutorial-series/multinode.py
+++ b/distributed/ddp-tutorial-series/multinode.py
@@ -37,7 +37,7 @@ class Trainer:
         self.model = DDP(self.model, device_ids=[self.local_rank])
 
     def _load_snapshot(self, snapshot_path):
-        loc = f"cuda:{self.gpu_id}"
+        loc = f"cuda:{self.local_rank}"
         snapshot = torch.load(snapshot_path, map_location=loc)
         self.model.load_state_dict(snapshot["MODEL_STATE"])
         self.epochs_run = snapshot["EPOCHS_RUN"]


### PR DESCRIPTION
I fixed a small bug in the ddp multinode tutorial which does not allow the loading of snapshots (`AttributeError: 'Trainer' object has no attribute 'gpu_id'`). It looks like the `_load_snapshot` method was copied over from `multigpu_torchrun.py` but the attribute `gpu_id` was not renamed to `local_rank`.