### PR TITLE
Replace list with deque.

### DIFF
--- a/reinforcement_learning/actor_critic.py
+++ b/reinforcement_learning/actor_critic.py
@@ -2,7 +2,7 @@ import argparse
 import gym
 import numpy as np
 from itertools import count
-from collections import namedtuple
+from collections import namedtuple, deque
 
 import torch
 import torch.nn as nn
@@ -99,13 +99,13 @@ def finish_episode():
     saved_actions = model.saved_actions
     policy_losses = [] # list to save actor (policy) loss
     value_losses = [] # list to save critic (value) loss
-    returns = [] # list to save the true values
+    returns = deque() # list to save the true values
 
     # calculate the true value using rewards returned from the environment
     for r in model.rewards[::-1]:
         # calculate the discounted value
         R = r + args.gamma * R
-        returns.insert(0, R)
+        returns.appendleft(R)
 
     returns = torch.tensor(returns)
     returns = (returns - returns.mean()) / (returns.std() + eps)


### PR DESCRIPTION
FIX

Same PR for #1083
(There is no difference between the actor_critic.py example and reinforcement.py in using `returns`.)

The time complexity of `returns.append(0, R)` inserting at index 0 of the return list is O(N), and this can be reduced to O(1) by using a deque instead of a list.

According to the python docs:

> Deques support thread-safe, memory efficient appends and pops from either side of the deque with approximately the same O(1) performance in either direction.

> Though [list](https://docs.python.org/3/library/stdtypes.html#list) objects support similar operations, they are optimized for fast fixed-length operations and incur O(n) memory movement costs for pop(0) and insert(0, v) operations which change both the size and position of the underlying data representation.

The relevant official explanation is described on the site below.
https://docs.python.org/3/library/collections.html#collections.deque

