### PR TITLE
Add logic to resume ImageNet example with new learning rate

### DIFF
--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -215,6 +215,9 @@ def main_worker(gpu, ngpus_per_node, args):
                 best_acc1 = best_acc1.to(args.gpu)
             model.load_state_dict(checkpoint['state_dict'])
             optimizer.load_state_dict(checkpoint['optimizer'])
+            if args.lr:
+                # resume with newly specified learning rate
+                optimizer.param_groups[0]['lr'] = args.lr
             scheduler.load_state_dict(checkpoint['scheduler'])
             print("=> loaded checkpoint '{}' (epoch {})"
                   .format(args.resume, checkpoint['epoch']))
@@ -293,8 +296,8 @@ def main_worker(gpu, ngpus_per_node, args):
                 'arch': args.arch,
                 'state_dict': model.state_dict(),
                 'best_acc1': best_acc1,
-                'optimizer' : optimizer.state_dict(),
-                'scheduler' : scheduler.state_dict()
+                'optimizer': optimizer.state_dict(),
+                'scheduler': scheduler.state_dict()
             }, is_best)
 
 

--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -215,7 +215,7 @@ def main_worker(gpu, ngpus_per_node, args):
                 best_acc1 = best_acc1.to(args.gpu)
             model.load_state_dict(checkpoint['state_dict'])
             optimizer.load_state_dict(checkpoint['optimizer'])
-            if args.lr:
+            if args.lr != parser.get_default('lr'):
                 # resume with newly specified learning rate
                 optimizer.param_groups[0]['lr'] = args.lr
             scheduler.load_state_dict(checkpoint['scheduler'])


### PR DESCRIPTION
Fixes #816 

Resume no longer overwrites learning rate specific on command line. 

(My linter also removed 2 extraneous spaces in a `dict`, I can revert this if desired 🙂)