### PR TITLE
typo fix: multi-node training command in imagenet/

### DIFF
--- a/imagenet/README.md
+++ b/imagenet/README.md
@@ -52,7 +52,7 @@ python main.py -a resnet50 --dist-url 'tcp://IP_OF_NODE0:FREEPORT' --dist-backen
 Node 1:
 
 ```bash
-python main.py -a resnet50 --dist-url 'tcp://IP_OF_NODE0:FREEPORT' --dist-backend 'nccl' --multiprocessing-distributed --world-size 2 --rank 1 [imagenet-folder with train and val folders]
+python main.py -a resnet50 --dist-url 'tcp://IP_OF_NODE1:FREEPORT' --dist-backend 'nccl' --multiprocessing-distributed --world-size 2 --rank 1 [imagenet-folder with train and val folders]
 ```
 
 ## Usage


### PR DESCRIPTION
Hi there, I noticed that in imagenet/README.md, when using multi-node distributed training, the value of param '--dist-url' of node 1 should not be `IP_OF_NODE0`, but `IP_OF_NODE1`. I guess it was just a typo :)