### PR TITLE
Fix optional arguments error in vae examples readme.md

### DIFF
--- a/vae/README.md
+++ b/vae/README.md
@@ -15,7 +15,7 @@ optional arguments:
   --batch-size		input batch size for training (default: 128)
   --epochs		number of epochs to train (default: 10)
   --no-cuda		enables CUDA training
-  --mps         enables GPU on macOS
+  --no-mps         enables GPU on macOS
   --seed		random seed (default: 1)
   --log-interval	how many batches to wait before logging training status
 ```


### PR DESCRIPTION
`--no-mps` in code, but `--mps` in `README.md` , I have corrected this error.