### PR TITLE
Adds torch.cuda.set_device calls to DDP examples

### DIFF
--- a/distributed/ddp-tutorial-series/multigpu.py
+++ b/distributed/ddp-tutorial-series/multigpu.py
@@ -19,6 +19,7 @@ def ddp_setup(rank, world_size):
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = "12355"
     init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    torch.cuda.set_device(rank)
 
 class Trainer:
     def __init__(

--- a/distributed/ddp-tutorial-series/multigpu_torchrun.py
+++ b/distributed/ddp-tutorial-series/multigpu_torchrun.py
@@ -12,6 +12,7 @@ import os
 
 def ddp_setup():
     init_process_group(backend="nccl")
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
 
 class Trainer:
     def __init__(

--- a/distributed/ddp-tutorial-series/multinode.py
+++ b/distributed/ddp-tutorial-series/multinode.py
@@ -12,6 +12,7 @@ import os
 
 def ddp_setup():
     init_process_group(backend="nccl")
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
 
 class Trainer:
     def __init__(

--- a/distributed/minGPT-ddp/mingpt/main.py
+++ b/distributed/minGPT-ddp/mingpt/main.py
@@ -8,6 +8,7 @@ from torch.distributed import init_process_group, destroy_process_group
 
 def ddp_setup():
     init_process_group(backend="nccl")
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
 
 def get_train_objs(gpt_cfg: GPTConfig, opt_cfg: OptimizerConfig, data_cfg: DataConfig):
     dataset = CharDataset(data_cfg)


### PR DESCRIPTION
The recommended best practice to avoid hangs and high memory utilization on GPU:0 is to `set_device(i)` which switches the default from GPU:0 to GPU:i