### PR TITLE
Use gymnasium and reflect new API

### DIFF
--- a/distributed/rpc/rl/requirements.txt
+++ b/distributed/rpc/rl/requirements.txt
@@ -1,3 +1,3 @@
 torch
 numpy
-gym
+gymnasium


### PR DESCRIPTION
Reflect newer gym in the RPC RL example as [gym](https://github.com/openai/gym) moves to [gymnasium](https://github.com/Farama-Foundation/Gymnasium) and the current example does not work with gymnasium or newest gym version. [Reference](https://gymnasium.farama.org/content/migration-guide/)