### PR TITLE
Fix import in minGPT example

### DIFF
--- a/distributed/minGPT-ddp/mingpt/main.py
+++ b/distributed/minGPT-ddp/mingpt/main.py
@@ -1,3 +1,4 @@
+import os
 import torch
 from torch.utils.data import random_split
 from torch.distributed import init_process_group, destroy_process_group


### PR DESCRIPTION
Fix simple import error

```sh
Traceback (most recent call last):
  File "mingpt/main.py", line 29, in main
    ddp_setup()
  File "mingpt/main.py", line 13, in ddp_setup
    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
NameError: name 'os' is not defined
```