### PR TITLE
fix zero_grad default parameter

### DIFF
--- a/distributed/rpc/batch/parameter_server.py
+++ b/distributed/rpc/batch/parameter_server.py
@@ -54,7 +54,7 @@ class BatchUpdateParameterServer(object):
                     p.grad /= self.batch_update_size
                 self.curr_update_size = 0
                 self.optimizer.step()
-                self.optimizer.zero_grad()
+                self.optimizer.zero_grad(set_to_none=False)
                 fut.set_result(self.model)
                 timed_log("PS updated model")
                 self.future_model = torch.futures.Future()


### PR DESCRIPTION
In PyTorch 2.0, the default setting of "set_to_none" in "zero_grad" is True, which leads to TypeError when accumulating gradients in BatchUpdateParameterServer.


Ref:
[torch.optim.SGD.zero_grad in PyTorch 2.0](https://pytorch.org/docs/2.0/generated/torch.optim.SGD.html?highlight=zero_grad#torch.optim.SGD.zero_grad)
[torch.optim.SGD.zero_grad in PyTorch 1.13](https://pytorch.org/docs/1.13/generated/torch.optim.SGD.html?highlight=zero_grad#torch.optim.SGD.zero_grad)