### PR TITLE
[TorchFix] Update deprecated TorchVision pretrained parameters

### DIFF
--- a/cpp/transfer-learning/convert.py
+++ b/cpp/transfer-learning/convert.py
@@ -5,7 +5,7 @@ import torch
 from torchvision import models
 
 # Download and load the pre-trained model
-model = models.resnet18(pretrained=True)
+model = models.resnet18(weights=models.ResNet18_Weights.IMAGENET1K_V1)
 
 # Set upgrading the gradients to False
 for param in model.parameters():

--- a/fast_neural_style/neural_style/vgg.py
+++ b/fast_neural_style/neural_style/vgg.py
@@ -7,7 +7,7 @@ from torchvision import models
 class Vgg16(torch.nn.Module):
     def __init__(self, requires_grad=False):
         super(Vgg16, self).__init__()
-        vgg_pretrained_features = models.vgg16(pretrained=True).features
+        vgg_pretrained_features = models.vgg16(weights=models.VGG16_Weights.IMAGENET1K_V1).features
         self.slice1 = torch.nn.Sequential()
         self.slice2 = torch.nn.Sequential()
         self.slice3 = torch.nn.Sequential()


### PR DESCRIPTION
For TorchVision models, `pretrained` parameters have been deprecated in favor of "Multi-weight support API" - see https://pytorch.org/vision/0.15/models.html