### PR TITLE
simpler subsequent mask generator

### DIFF
--- a/word_language_model/model.py
+++ b/word_language_model/model.py
@@ -120,9 +120,7 @@ class TransformerModel(nn.Transformer):
         self.init_weights()
 
     def _generate_square_subsequent_mask(self, sz):
-        mask = (torch.triu(torch.ones(sz, sz)) == 1).transpose(0, 1)
-        mask = mask.float().masked_fill(mask == 0, float('-inf')).masked_fill(mask == 1, float(0.0))
-        return mask
+        return torch.log(torch.tril(torch.ones(sz,sz)))
 
     def init_weights(self):
         initrange = 0.1


### PR DESCRIPTION
Same result as before:

```python
In [29]: sz = 4

In [30]: mask = (torch.triu(torch.ones(sz, sz)) == 1).transpose(0, 1)

In [31]: mask.float().masked_fill(mask == 0, float('-inf')).masked_fill(mask == 1, float(0.0))
Out[31]:
tensor([[0., -inf, -inf, -inf],
        [0., 0., -inf, -inf],
        [0., 0., 0., -inf],
        [0., 0., 0., 0.]])

In [32]: torch.log(torch.tril(torch.ones(sz,sz))) #### proposed change ####
Out[32]:
tensor([[0., -inf, -inf, -inf],
        [0., 0., -inf, -inf],
        [0., 0., 0., -inf],
        [0., 0., 0., 0.]])
```