### PR TITLE
Bugfix in vision transformer - save class token and pos embedding

### DIFF
--- a/vision_transformer/main.py
+++ b/vision_transformer/main.py
@@ -49,9 +49,9 @@ class InputEmbedding(nn.Module):
         # Linear projection
         self.LinearProjection = nn.Linear(self.input_size, self.latent_size)
         # Class token
-        self.class_token = nn.Parameter(torch.randn(self.batch_size, 1, self.latent_size)).to(self.device)
+        self.class_token = nn.Parameter(torch.randn(self.batch_size, 1, self.latent_size).to(self.device))
         # Positional embedding
-        self.pos_embedding = nn.Parameter(torch.randn(self.batch_size, 1, self.latent_size)).to(self.device)
+        self.pos_embedding = nn.Parameter(torch.randn(self.batch_size, 1, self.latent_size).to(self.device))
 
     def forward(self, input_data):
         input_data = input_data.to(self.device)


### PR DESCRIPTION
When saving model's learned parameters the class token and positional embedding parameters where not saved. This happened because these parameters where lost when moving the model to the GPU (as explained [here](https://discuss.pytorch.org/t/empty-state-dict-after-moving-model-to-gpu/21069)). I guess this was the reason different tensors where returned when running with the same weights loaded from the saved model, as mentioned [here](https://github.com/pytorch/examples/issues/1184#issuecomment-1783659171).