### PR TITLE
update-minimum-cmake-version to version 3.5

### DIFF
--- a/cpp/autograd/CMakeLists.txt
+++ b/cpp/autograd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(autograd)
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp/custom-dataset/CMakeLists.txt
+++ b/cpp/custom-dataset/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(custom-dataset)
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp/dcgan/CMakeLists.txt
+++ b/cpp/dcgan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 project(dcgan)
 
 find_package(Torch REQUIRED)

--- a/cpp/distributed/CMakeLists.txt
+++ b/cpp/distributed/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 project(dist-mnist)
 
 find_package(Torch REQUIRED)

--- a/cpp/mnist/CMakeLists.txt
+++ b/cpp/mnist/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 project(mnist)
 set(CMAKE_CXX_STANDARD 17)
 

--- a/cpp/regression/CMakeLists.txt
+++ b/cpp/regression/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(regression)
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp/transfer-learning/CMakeLists.txt
+++ b/cpp/transfer-learning/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(example)
 
 find_package(Torch REQUIRED)


### PR DESCRIPTION
Update the cmake minimum version per cmake deprecation warning:

```
[cmake] CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
[cmake]   Compatibility with CMake < 3.5 will be removed from a future version of
[cmake]   CMake.

```