### PR TITLE
Fix the DCGAN C++ shape warning

### DIFF
--- a/cpp/dcgan/dcgan.cpp
+++ b/cpp/dcgan/dcgan.cpp
@@ -142,7 +142,7 @@ int main(int argc, const char* argv[]) {
       torch::Tensor real_images = batch.data.to(device);
       torch::Tensor real_labels =
           torch::empty(batch.data.size(0), device).uniform_(0.8, 1.0);
-      torch::Tensor real_output = discriminator->forward(real_images);
+      torch::Tensor real_output = discriminator->forward(real_images).reshape(real_labels.sizes());
       torch::Tensor d_loss_real =
           torch::binary_cross_entropy(real_output, real_labels);
       d_loss_real.backward();
@@ -152,7 +152,7 @@ int main(int argc, const char* argv[]) {
           torch::randn({batch.data.size(0), kNoiseSize, 1, 1}, device);
       torch::Tensor fake_images = generator->forward(noise);
       torch::Tensor fake_labels = torch::zeros(batch.data.size(0), device);
-      torch::Tensor fake_output = discriminator->forward(fake_images.detach());
+      torch::Tensor fake_output = discriminator->forward(fake_images.detach()).reshape(fake_labels.sizes());
       torch::Tensor d_loss_fake =
           torch::binary_cross_entropy(fake_output, fake_labels);
       d_loss_fake.backward();
@@ -163,7 +163,7 @@ int main(int argc, const char* argv[]) {
       // Train generator.
       generator->zero_grad();
       fake_labels.fill_(1);
-      fake_output = discriminator->forward(fake_images);
+      fake_output = discriminator->forward(fake_images).reshape(fake_labels.sizes());
       torch::Tensor g_loss =
           torch::binary_cross_entropy(fake_output, fake_labels);
       g_loss.backward();


### PR DESCRIPTION
The cpp/dcgan shape warning has been discussed in https://github.com/pytorch/examples/issues/819. This PR adopted the solution mentioned in the issue and tested with the up-to-date libtorch (2.1.2) with cuda 12.1 using both the release and debug build.