### PR TITLE
Update the readme and fix bugs in custom-dataset example

### DIFF
--- a/cpp/custom-dataset/README.md
+++ b/cpp/custom-dataset/README.md
@@ -2,7 +2,7 @@
 
 This folder contains an example of loading a custom image dataset with OpenCV and training a model to label images, using the PyTorch C++ frontend.
 
-The dataset used here is [Caltech 101](http://www.vision.caltech.edu/Image_Datasets/Caltech101/) dataset.
+The dataset used here is [Caltech 101](https://data.caltech.edu/records/mzrjq-6wc02) dataset.
 
 The entire training code is contained in custom-data.cpp.
 


### PR DESCRIPTION
1. Update the Caltech 101 dataset URL in readme.
2. `random_shuffle`: is not a member of 'std' since it c++17, updated to `shuffle`.
3. `Functional(torch::log_softmax, 1, torch::nullopt)` no longer matches the constructor, updated to lambda expression.
4. `auto tlabel = torch::from_blob(&data[index].second, {1}, torch::kLong);` sometimes leads to non-sensical numerical value. 
A few examples from std::cout:
```
data[index].second: 42 
tlabel:  42 [ CPULongType{1} ] 
data[index].second: 10 
tlabel:  10 [ CPULongType{1} ] 
data[index].second: 98 
tlabel:  4.6698e+16
```
Updated to direct the creation of a tensor instead of creation from a pointer.

Tested the program via libtorch (2.1.2) with cuda 12.1 using both the release and debug build.
