### PR TITLE
Ensure the const-ness of the data member

### DIFF
--- a/cpp/custom-dataset/custom-dataset.cpp
+++ b/cpp/custom-dataset/custom-dataset.cpp
@@ -26,7 +26,7 @@ using Data = std::vector<std::pair<std::string, long>>;
 class CustomDataset : public torch::data::datasets::Dataset<CustomDataset> {
   using Example = torch::data::Example<>;
 
-  Data data;
+  const Data data;
 
  public:
   CustomDataset(const Data& data) : data(data) {}
@@ -198,7 +198,7 @@ int main() {
   std::cout << "Running on: "
             << (options.device == torch::kCUDA ? "CUDA" : "CPU") << std::endl;
 
-  auto data = readInfo();
+  const auto data = readInfo();
 
   auto train_set =
       CustomDataset(data.first).map(torch::data::transforms::Stack<>());


### PR DESCRIPTION
## Summary
The `data` variable loads from the info.txt and encodes the info in pair <image path, ground truth label>.
The program should not modify this information during the execution and thus ensure the const-ness of the `data` variable.

## Testing Done 
Tested the program via libtorch (2.1.2) with cuda 12.1 using both the release and debug build.