### PR TITLE
Add a CI job for cpp/dcgan

### DIFF
--- a/run_cpp_examples.sh
+++ b/run_cpp_examples.sh
@@ -94,6 +94,21 @@ function custom-dataset() {
     exit 1
   fi
 }
+function dcgan() {
+  start
+  mkdir build
+  cd build
+  cmake -DCMAKE_PREFIX_PATH=$LIBTORCH_PATH ..
+  make
+  if [ $? -eq 0 ]; then
+    echo "Successfully built $EXAMPLE"
+    ./$EXAMPLE # Run the executable
+    check_run_success $EXAMPLE
+  else
+    error "Failed to build $EXAMPLE"
+    exit 1
+  fi
+}
 
 function mnist() {
   start
@@ -141,6 +156,7 @@ function clean() {
 function run_all() {
   autograd
   custom-dataset
+  dcgan
   mnist
   regression
 }


### PR DESCRIPTION
Add a CI job for cpp/dcgan. 
Currently, run cpp test costs 2h 12m 35s since 30 epochs of dcgan on CPU is quite time-consuming.
A potential speed-up (not covered in this PR) is to make the number of epochs as a command line arg in cpp/dcgan and run only a few epochs in the CI job. 
