### PR TITLE
Improve code readability and make number of epochs a command line argument

### DIFF
--- a/.github/workflows/main_cpp.yml
+++ b/.github/workflows/main_cpp.yml
@@ -31,7 +31,14 @@ jobs:
       run: |
         sudo apt -y install libtbb-dev
         sudo apt install libopencv-dev
-
+    - name: Install argparse
+      run: |
+        git clone https://github.com/p-ranav/argparse
+        cd argparse
+        mkdir build
+        cd build
+        cmake -DARGPARSE_BUILD_SAMPLES=off -DARGPARSE_BUILD_TESTS=off ..
+        sudo make install
     # Alternatively, you can install OpenCV from source
     # - name: Install OpenCV from source
     #   run: |

--- a/cpp/dcgan/dcgan.cpp
+++ b/cpp/dcgan/dcgan.cpp
@@ -1,5 +1,5 @@
 #include <torch/torch.h>
-
+#include <argparse/argparse.hpp>
 #include <cmath>
 #include <cstdio>
 #include <iostream>
@@ -9,9 +9,6 @@ const int64_t kNoiseSize = 100;
 
 // The batch size for training.
 const int64_t kBatchSize = 64;
-
-// The default number of epochs to train.
-int64_t kNumberOfEpochs = 30;
 
 // Where to find the MNIST dataset.
 const char* kDataFolder = "./data";
@@ -95,18 +92,22 @@ nn::Sequential create_discriminator() {
 }
 
 int main(int argc, const char* argv[]) {
-
-  if (argc > 1) {
-      std::string arg = argv[1];
-      if (std::all_of(arg.begin(), arg.end(), ::isdigit)) {
-          try {
-              kNumberOfEpochs = std::stoll(arg);
-          } catch (const std::invalid_argument& ia) {
-              // If unable to parse, do nothing and keep the default value
-          }
-      }
+  argparse::ArgumentParser parser("cpp/dcgan example");
+  parser.add_argument("--epochs")
+      .help("Number of epochs to train")
+      .default_value(std::int64_t{30})
+      .scan<'i', int64_t>();
+  try {
+    parser.parse_args(argc, argv);
+  } catch (const std::exception& err) {
+    std::cout << err.what() << std::endl;
+    std::cout << parser;
+    std::exit(1);
   }
-  std::cout << "Traning with number of epochs: " << kNumberOfEpochs << std::endl;
+  // The number of epochs to train, default value is 30.
+  const int64_t kNumberOfEpochs = parser.get<int64_t>("--epochs");
+  std::cout << "Traning with number of epochs: " << kNumberOfEpochs
+            << std::endl;
 
   torch::manual_seed(1);
 

--- a/cpp/dcgan/dcgan.cpp
+++ b/cpp/dcgan/dcgan.cpp
@@ -10,8 +10,8 @@ const int64_t kNoiseSize = 100;
 // The batch size for training.
 const int64_t kBatchSize = 64;
 
-// The number of epochs to train.
-const int64_t kNumberOfEpochs = 30;
+// The default number of epochs to train.
+int64_t kNumberOfEpochs = 30;
 
 // Where to find the MNIST dataset.
 const char* kDataFolder = "./data";
@@ -75,7 +75,39 @@ struct DCGANGeneratorImpl : nn::Module {
 
 TORCH_MODULE(DCGANGenerator);
 
+nn::Sequential create_discriminator() {
+    return nn::Sequential(
+     // Layer 1
+     nn::Conv2d(nn::Conv2dOptions(1, 64, 4).stride(2).padding(1).bias(false)),
+     nn::LeakyReLU(nn::LeakyReLUOptions().negative_slope(0.2)),
+     // Layer 2
+     nn::Conv2d(nn::Conv2dOptions(64, 128, 4).stride(2).padding(1).bias(false)),
+     nn::BatchNorm2d(128),
+     nn::LeakyReLU(nn::LeakyReLUOptions().negative_slope(0.2)),
+     // Layer 3
+     nn::Conv2d(
+         nn::Conv2dOptions(128, 256, 4).stride(2).padding(1).bias(false)),
+     nn::BatchNorm2d(256),
+     nn::LeakyReLU(nn::LeakyReLUOptions().negative_slope(0.2)),
+     // Layer 4
+     nn::Conv2d(nn::Conv2dOptions(256, 1, 3).stride(1).padding(0).bias(false)),
+     nn::Sigmoid());
+}
+
 int main(int argc, const char* argv[]) {
+
+  if (argc > 1) {
+      std::string arg = argv[1];
+      if (std::all_of(arg.begin(), arg.end(), ::isdigit)) {
+          try {
+              kNumberOfEpochs = std::stoll(arg);
+          } catch (const std::invalid_argument& ia) {
+              // If unable to parse, do nothing and keep the default value
+          }
+      }
+  }
+  std::cout << "Traning with number of epochs: " << kNumberOfEpochs << std::endl;
+
   torch::manual_seed(1);
 
   // Create the device we pass around based on whether CUDA is available.
@@ -88,33 +120,15 @@ int main(int argc, const char* argv[]) {
   DCGANGenerator generator(kNoiseSize);
   generator->to(device);
 
-  nn::Sequential discriminator(
-      // Layer 1
-      nn::Conv2d(
-          nn::Conv2dOptions(1, 64, 4).stride(2).padding(1).bias(false)),
-      nn::LeakyReLU(nn::LeakyReLUOptions().negative_slope(0.2)),
-      // Layer 2
-      nn::Conv2d(
-          nn::Conv2dOptions(64, 128, 4).stride(2).padding(1).bias(false)),
-      nn::BatchNorm2d(128),
-      nn::LeakyReLU(nn::LeakyReLUOptions().negative_slope(0.2)),
-      // Layer 3
-      nn::Conv2d(
-          nn::Conv2dOptions(128, 256, 4).stride(2).padding(1).bias(false)),
-      nn::BatchNorm2d(256),
-      nn::LeakyReLU(nn::LeakyReLUOptions().negative_slope(0.2)),
-      // Layer 4
-      nn::Conv2d(
-          nn::Conv2dOptions(256, 1, 3).stride(1).padding(0).bias(false)),
-      nn::Sigmoid());
+  nn::Sequential discriminator = create_discriminator();
   discriminator->to(device);
 
   // Assume the MNIST dataset is available under `kDataFolder`;
   auto dataset = torch::data::datasets::MNIST(kDataFolder)
                      .map(torch::data::transforms::Normalize<>(0.5, 0.5))
                      .map(torch::data::transforms::Stack<>());
-  const int64_t batches_per_epoch =
-      std::ceil(dataset.size().value() / static_cast<double>(kBatchSize));
+  const int64_t batches_per_epoch = static_cast<int64_t>(
+      std::ceil(dataset.size().value() / static_cast<double>(kBatchSize)));
 
   auto data_loader = torch::data::make_data_loader(
       std::move(dataset),
@@ -136,7 +150,7 @@ int main(int argc, const char* argv[]) {
   int64_t checkpoint_counter = 1;
   for (int64_t epoch = 1; epoch <= kNumberOfEpochs; ++epoch) {
     int64_t batch_index = 0;
-    for (torch::data::Example<>& batch : *data_loader) {
+    for (const torch::data::Example<>& batch : *data_loader) {
       // Train discriminator with real images.
       discriminator->zero_grad();
       torch::Tensor real_images = batch.data.to(device);

--- a/run_cpp_examples.sh
+++ b/run_cpp_examples.sh
@@ -102,7 +102,7 @@ function dcgan() {
   make
   if [ $? -eq 0 ]; then
     echo "Successfully built $EXAMPLE"
-    ./$EXAMPLE # Run the executable
+    ./$EXAMPLE 5 # Run the executable with kNumberOfEpochs = 5
     check_run_success $EXAMPLE
   else
     error "Failed to build $EXAMPLE"

--- a/run_cpp_examples.sh
+++ b/run_cpp_examples.sh
@@ -102,7 +102,7 @@ function dcgan() {
   make
   if [ $? -eq 0 ]; then
     echo "Successfully built $EXAMPLE"
-    ./$EXAMPLE 5 # Run the executable with kNumberOfEpochs = 5
+    ./$EXAMPLE --epochs 5 # Run the executable with kNumberOfEpochs = 5
     check_run_success $EXAMPLE
   else
     error "Failed to build $EXAMPLE"


### PR DESCRIPTION
## Summary

- Make number of epochs a command line argument, the CI job runs 5 epoch (compared to its default value of 30) to reduce the overall testing time
<img width="500" alt="Screenshot 2024-01-24 at 2 01 36 PM" src="https://github.com/pytorch/examples/assets/7495155/38fa5f73-a834-430f-a9da-8bd510d9ca12">


- Improve code readability by separating the discriminator creation from the main function.
- `const referece` in  `const torch::data::Example<>& batch : *data_loader` is standard (compared with the non-const version ` torch::data::Example<>& batch : *data_loader`).
- fix warning C4244: 'initializing': conversion from 'double' to 'int64_t', possible loss of data and warning C4244: 'initializing': conversion from 'double' to 'const int64_t', possible loss of data 
with change
`const int64_t batches_per_epoch =
    static_cast<int64_t>(std::ceil(dataset.size().value() / static_cast<double>(kBatchSize)));`

