### PR TITLE
Improve readme for cpp/custom-dataset and cpp/dcgan

### DIFF
--- a/cpp/custom-dataset/README.md
+++ b/cpp/custom-dataset/README.md
@@ -20,7 +20,7 @@ $ make
 
 where /path/to/libtorch should be the path to the unzipped LibTorch distribution, which you can get from the [PyTorch homepage](https://pytorch.org/get-started/locally/).
 
-if you see an error like `undefined reference to cv::imread(std::string const&, int)` when running the `make` command, you should build LibTorch from source using the instructions [here](https://github.com/pytorch/pytorch#from-source), and then set `CMAKE_PREFIX_PATH` to that PyTorch source directory.
+If you see an error like `undefined reference to cv::imread(std::string const&, int)` when running the `make` command, you should build LibTorch from source using the instructions [here](https://github.com/pytorch/pytorch#from-source), and then set `CMAKE_PREFIX_PATH` to that PyTorch source directory. An alternative solution is to use `libtorch-cxx11-abi-shared-with-deps` instead of `libtorch-shared-with-deps` as the latter is not compatible with openCV (reported [here](https://discuss.pytorch.org/t/library-conflict-between-libtorch-and-opencv/64489)).
 
 The build directory should look like this:
 

--- a/cpp/dcgan/README.md
+++ b/cpp/dcgan/README.md
@@ -5,6 +5,8 @@ with the PyTorch C++ frontend.
 
 The entire training code is contained in `dcgan.cpp`.
 
+You can find the commands to install argparse [here](https://github.com/pytorch/examples/blob/main/.github/workflows/main_cpp.yml#L34).
+
 To build the code, run the following commands from your terminal:
 
 ```shell
@@ -45,6 +47,14 @@ $ ./dcgan
 -> checkpoint 10
 ...
 ```
+
+We can also specify the `--epochs` to change the number of epochs to train as follows:
+
+```shell
+$ ./dcgan --epochs 10
+```
+Without specifying the `--epochs` flag, the default number of epochs to train is 30.
+
 
 The training script periodically generates image samples. Use the
 `display_samples.py` script situated in this folder to generate a plot image.


### PR DESCRIPTION
1. In cpp/custom-dataset: add a short remark regarding we should use `libtorch-cxx11-abi-shared-with-deps` instead of `libtorch-shared-with-deps` when seeing an error like undefined reference to cv::imread(std::string const&, int) by running the make command.
2. In cpp/dcgan: add a remark on the `--epochs` flag.