### PR TITLE
Allow for bigger action space in actor-critic example

### DIFF
--- a/reinforcement_learning/actor_critic.py
+++ b/reinforcement_learning/actor_critic.py
@@ -111,13 +111,13 @@ def finish_episode():
     returns = (returns - returns.mean()) / (returns.std() + eps)
 
     for (log_prob, value), R in zip(saved_actions, returns):
-        advantage = R - value.item()
+        advantage = R - torch.tensor(value.tolist())
 
         # calculate actor (policy) loss
         policy_losses.append(-log_prob * advantage)
 
         # calculate critic (value) loss using L1 smooth loss
-        value_losses.append(F.smooth_l1_loss(value, torch.tensor([R])))
+        value_losses.append(F.smooth_l1_loss(value, torch.tensor([R] * len(value))))
 
     # reset gradients
     optimizer.zero_grad()


### PR DESCRIPTION
Using vector instead of single value will allow to use this example with environments with bigger action space, like LunarLander