### PR TITLE
Fix the MNIST dataset url

### DIFF
--- a/cpp/tools/download_mnist.py
+++ b/cpp/tools/download_mnist.py
@@ -78,7 +78,7 @@ def main():
         for resource in RESOURCES:
             path = os.path.join(options.destination, resource)
             # url = 'http://yann.lecun.com/exdb/mnist/{}'.format(resource)
-            url = 'https://ossci-datasets.s3.amazonaws.com/mnist/'.format(resource)
+            url = 'https://ossci-datasets.s3.amazonaws.com/mnist/{}'.format(resource)
             download(path, url, options.quiet)
             unzip(path, options.quiet)
     except KeyboardInterrupt:

--- a/cpp/tools/download_mnist.py
+++ b/cpp/tools/download_mnist.py
@@ -77,7 +77,8 @@ def main():
     try:
         for resource in RESOURCES:
             path = os.path.join(options.destination, resource)
-            url = 'http://yann.lecun.com/exdb/mnist/{}'.format(resource)
+            # url = 'http://yann.lecun.com/exdb/mnist/{}'.format(resource)
+            url = 'https://ossci-datasets.s3.amazonaws.com/mnist/'.format(resource)
             download(path, url, options.quiet)
             unzip(path, options.quiet)
     except KeyboardInterrupt:

--- a/run_cpp_examples.sh
+++ b/run_cpp_examples.sh
@@ -157,10 +157,8 @@ function run_all() {
   autograd
   custom-dataset
   regression
-  
-  # dataset 503 error on yanns site
-  # dcgan
-  # mnist
+  dcgan
+  mnist
   
 }
 


### PR DESCRIPTION
The URL `https://ossci-datasets.s3.amazonaws.com/mnist/` is extracted 
via 
```
from torchvision import datasets
datasets.MNIST(".", download=True)
```

output
```
Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz
Failed to download (trying next):
HTTP Error 403: Forbidden
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz to ./MNIST/raw/train-images-idx3-ubyte.gz
100%|██████████| 9912422/9912422 [00:00<00:00, 14826948.05it/s]
Extracting ./MNIST/raw/train-images-idx3-ubyte.gz to ./MNIST/raw
Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz
Failed to download (trying next):
HTTP Error 403: Forbidden
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz to ./MNIST/raw/train-labels-idx1-ubyte.gz
100%|██████████| 28881/28881 [00:00<00:00, 359273.99it/s]
Extracting ./MNIST/raw/train-labels-idx1-ubyte.gz to ./MNIST/raw
Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz
Failed to download (trying next):
HTTP Error 403: Forbidden
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz to ./MNIST/raw/t10k-images-idx3-ubyte.gz
100%|██████████| 1648877/1648877 [00:00<00:00, 3366753.80it/s]
Extracting ./MNIST/raw/t10k-images-idx3-ubyte.gz to ./MNIST/raw
Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
Failed to download (trying next):
HTTP Error 403: Forbidden
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz to ./MNIST/raw/t10k-labels-idx1-ubyte.gz
100%|██████████| 4542/4542 [00:00<00:00, 4132435.74it/s]
Extracting ./MNIST/raw/t10k-labels-idx1-ubyte.gz to ./MNIST/raw
```

CI jobs enabled and succeeded. 
@msaroufim 