### PR TITLE
Remove the unused import in MNIST example

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import argparse
 import torch
 import torch.nn as nn


### PR DESCRIPTION
Remove the unused import in MNIST example