### PR TITLE
Fix argument help descriptions to match default values

### DIFF
--- a/distributed/FSDP/T5_training.py
+++ b/distributed/FSDP/T5_training.py
@@ -198,11 +198,11 @@ if __name__ == '__main__':
     # Training settings
     parser = argparse.ArgumentParser(description='PyTorch T5 FSDP Example')
     parser.add_argument('--batch-size', type=int, default=4, metavar='N',
-                        help='input batch size for training (default: 64)')
+                        help='input batch size for training (default: 4)')
     parser.add_argument('--test-batch-size', type=int, default=4, metavar='N',
-                        help='input batch size for testing (default: 1000)')
+                        help='input batch size for testing (default: 4)')
     parser.add_argument('--epochs', type=int, default=2, metavar='N',
-                        help='number of epochs to train (default: 3)')
+                        help='number of epochs to train (default: 2)')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')
     parser.add_argument('--track_memory', action='store_false', default=True,


### PR DESCRIPTION
This pull request fixes the descriptions of T5_training.py arguments to resolve discrepancies between the actual default values and their corresponding help descriptions.