### PR TITLE
Replace hardcoded default values in argparse help strings

### DIFF
--- a/distributed/FSDP/T5_training.py
+++ b/distributed/FSDP/T5_training.py
@@ -198,13 +198,13 @@ if __name__ == '__main__':
     # Training settings
     parser = argparse.ArgumentParser(description='PyTorch T5 FSDP Example')
     parser.add_argument('--batch-size', type=int, default=4, metavar='N',
-                        help='input batch size for training (default: 64)')
+                        help='input batch size for training (default: %(default)s)')
     parser.add_argument('--test-batch-size', type=int, default=4, metavar='N',
-                        help='input batch size for testing (default: 1000)')
+                        help='input batch size for testing (default: %(default)s)')
     parser.add_argument('--epochs', type=int, default=2, metavar='N',
-                        help='number of epochs to train (default: 3)')
+                        help='number of epochs to train (default: %(default)s)')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
-                        help='random seed (default: 1)')
+                        help='random seed (default: %(default)s)')
     parser.add_argument('--track_memory', action='store_false', default=True,
                         help='track the gpu memory')
     parser.add_argument('--run_validation', action='store_false', default=True,

--- a/distributed/ddp-tutorial-series/multigpu.py
+++ b/distributed/ddp-tutorial-series/multigpu.py
@@ -97,7 +97,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='simple distributed training job')
     parser.add_argument('total_epochs', type=int, help='Total epochs to train the model')
     parser.add_argument('save_every', type=int, help='How often to save a snapshot')
-    parser.add_argument('--batch_size', default=32, type=int, help='Input batch size on each device (default: 32)')
+    parser.add_argument('--batch_size', default=32, type=int,
+                        help='Input batch size on each device (default: %(default)s)')
     args = parser.parse_args()
 
     world_size = torch.cuda.device_count()

--- a/distributed/ddp-tutorial-series/multigpu_torchrun.py
+++ b/distributed/ddp-tutorial-series/multigpu_torchrun.py
@@ -105,7 +105,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='simple distributed training job')
     parser.add_argument('total_epochs', type=int, help='Total epochs to train the model')
     parser.add_argument('save_every', type=int, help='How often to save a snapshot')
-    parser.add_argument('--batch_size', default=32, type=int, help='Input batch size on each device (default: 32)')
+    parser.add_argument('--batch_size', default=32, type=int,
+                        help='Input batch size on each device (default: %(default)s)')
     args = parser.parse_args()
 
     main(args.save_every, args.total_epochs, args.batch_size)

--- a/distributed/ddp-tutorial-series/multinode.py
+++ b/distributed/ddp-tutorial-series/multinode.py
@@ -106,7 +106,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='simple distributed training job')
     parser.add_argument('total_epochs', type=int, help='Total epochs to train the model')
     parser.add_argument('save_every', type=int, help='How often to save a snapshot')
-    parser.add_argument('--batch_size', default=32, type=int, help='Input batch size on each device (default: 32)')
+    parser.add_argument('--batch_size', default=32, type=int,
+                        help='Input batch size on each device (default: %(default)s)')
     args = parser.parse_args()
 
     main(args.save_every, args.total_epochs, args.batch_size)

--- a/distributed/ddp-tutorial-series/single_gpu.py
+++ b/distributed/ddp-tutorial-series/single_gpu.py
@@ -11,7 +11,7 @@ class Trainer:
         train_data: DataLoader,
         optimizer: torch.optim.Optimizer,
         gpu_id: int,
-        save_every: int, 
+        save_every: int,
     ) -> None:
         self.gpu_id = gpu_id
         self.model = model.to(gpu_id)
@@ -75,8 +75,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='simple distributed training job')
     parser.add_argument('total_epochs', type=int, help='Total epochs to train the model')
     parser.add_argument('save_every', type=int, help='How often to save a snapshot')
-    parser.add_argument('--batch_size', default=32, type=int, help='Input batch size on each device (default: 32)')
+    parser.add_argument('--batch_size', default=32, type=int,
+                        help='Input batch size on each device (default: %(default)s)')
     args = parser.parse_args()
-    
+
     device = 0  # shorthand for cuda:0
     main(device, args.total_epochs, args.save_every, args.batch_size)

--- a/distributed/rpc/batch/reinforce.py
+++ b/distributed/rpc/batch/reinforce.py
@@ -21,11 +21,11 @@ OBSERVER_NAME = "observer{}"
 
 parser = argparse.ArgumentParser(description='PyTorch RPC Batch RL example')
 parser.add_argument('--gamma', type=float, default=1.0, metavar='G',
-                    help='discount factor (default: 1.0)')
+                    help='discount factor (default: %(default)s)')
 parser.add_argument('--seed', type=int, default=543, metavar='N',
-                    help='random seed (default: 543)')
+                    help='random seed (default: %(default)s)')
 parser.add_argument('--num-episode', type=int, default=10, metavar='E',
-                    help='number of episodes (default: 10)')
+                    help='number of episodes (default: %(default)s)')
 args = parser.parse_args()
 
 torch.manual_seed(args.seed)

--- a/distributed/rpc/rl/main.py
+++ b/distributed/rpc/rl/main.py
@@ -21,11 +21,11 @@ parser = argparse.ArgumentParser(description='PyTorch RPC RL example')
 parser.add_argument('--world-size', type=int, default=2, metavar='W',
                     help='world size for RPC, rank 0 is the agent, others are observers')
 parser.add_argument('--gamma', type=float, default=0.99, metavar='G',
-                    help='discount factor (default: 0.99)')
+                    help='discount factor (default: %(default)s)')
 parser.add_argument('--seed', type=int, default=543, metavar='N',
-                    help='random seed (default: 543)')
+                    help='random seed (default: %(default)s)')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',
-                    help='interval between training status logs (default: 10)')
+                    help='interval between training status logs (default: %(default)s)')
 args = parser.parse_args()
 
 torch.manual_seed(args.seed)

--- a/gat/main.py
+++ b/gat/main.py
@@ -292,21 +292,21 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='PyTorch Graph Attention Network')
     parser.add_argument('--epochs', type=int, default=300,
-                        help='number of epochs to train (default: 300)')
+                        help='number of epochs to train (default: %(default)s)')
     parser.add_argument('--lr', type=float, default=0.005,
-                        help='learning rate (default: 0.005)')
+                        help='learning rate (default: %(default)s)')
     parser.add_argument('--l2', type=float, default=5e-4,
-                        help='weight decay (default: 6e-4)')
+                        help='weight decay (default: %(default)s)')
     parser.add_argument('--dropout-p', type=float, default=0.6,
-                        help='dropout probability (default: 0.6)')
+                        help='dropout probability (default: %(default)s)')
     parser.add_argument('--hidden-dim', type=int, default=64,
-                        help='dimension of the hidden representation (default: 64)')
+                        help='dimension of the hidden representation (default: %(default)s)')
     parser.add_argument('--num-heads', type=int, default=8,
-                        help='number of the attention heads (default: 4)')
+                        help='number of the attention heads (default: %(default)s)')
     parser.add_argument('--concat-heads', action='store_true', default=False,
-                        help='wether to concatinate attention heads, or average over them (default: False)')
+                        help='wether to concatinate attention heads, or average over them (default: %(default)s)')
     parser.add_argument('--val-every', type=int, default=20,
-                        help='epochs to wait for print training and validation evaluation (default: 20)')
+                        help='epochs to wait for print training and validation evaluation (default: %(default)s)')
     parser.add_argument('--no-cuda', action='store_true', default=False,
                         help='disables CUDA training')
     parser.add_argument('--no-mps', action='store_true', default=False,
@@ -314,7 +314,7 @@ if __name__ == '__main__':
     parser.add_argument('--dry-run', action='store_true', default=False,
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=13, metavar='S',
-                        help='random seed (default: 13)')
+                        help='random seed (default: %(default)s)')
     args = parser.parse_args()
 
     torch.manual_seed(args.seed)

--- a/gcn/main.py
+++ b/gcn/main.py
@@ -203,19 +203,19 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='PyTorch Graph Convolutional Network')
     parser.add_argument('--epochs', type=int, default=200,
-                        help='number of epochs to train (default: 200)')
+                        help='number of epochs to train (default: %(default)s)')
     parser.add_argument('--lr', type=float, default=0.01,
-                        help='learning rate (default: 0.01)')
+                        help='learning rate (default: %(default)s)')
     parser.add_argument('--l2', type=float, default=5e-4,
-                        help='weight decay (default: 5e-4)')
+                        help='weight decay (default: %(default)s)')
     parser.add_argument('--dropout-p', type=float, default=0.5,
-                        help='dropout probability (default: 0.5)')
+                        help='dropout probability (default: %(default)s)')
     parser.add_argument('--hidden-dim', type=int, default=16,
-                        help='dimension of the hidden representation (default: 16)')
+                        help='dimension of the hidden representation (default: %(default)s)')
     parser.add_argument('--val-every', type=int, default=20,
-                        help='epochs to wait for print training and validation evaluation (default: 20)')
+                        help='epochs to wait for print training and validation evaluation (default: %(default)s)')
     parser.add_argument('--include-bias', action='store_true', default=False,
-                        help='use bias term in convolutions (default: False)')
+                        help='use bias term in convolutions (default: %(default)s)')
     parser.add_argument('--no-cuda', action='store_true', default=False,
                         help='disables CUDA training')
     parser.add_argument('--no-mps', action='store_true', default=False,
@@ -223,7 +223,7 @@ if __name__ == '__main__':
     parser.add_argument('--dry-run', action='store_true', default=False,
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=42, metavar='S',
-                        help='random seed (default: 42)')
+                        help='random seed (default: %(default)s)')
     args = parser.parse_args()
 
     use_cuda = not args.no_cuda and torch.cuda.is_available()

--- a/imagenet/main.py
+++ b/imagenet/main.py
@@ -27,21 +27,21 @@ model_names = sorted(name for name in models.__dict__
 
 parser = argparse.ArgumentParser(description='PyTorch ImageNet Training')
 parser.add_argument('data', metavar='DIR', nargs='?', default='imagenet',
-                    help='path to dataset (default: imagenet)')
+                    help='path to dataset (default: %(default)s)')
 parser.add_argument('-a', '--arch', metavar='ARCH', default='resnet18',
                     choices=model_names,
                     help='model architecture: ' +
                         ' | '.join(model_names) +
-                        ' (default: resnet18)')
+                        ' (default: %(default)s)')
 parser.add_argument('-j', '--workers', default=4, type=int, metavar='N',
-                    help='number of data loading workers (default: 4)')
+                    help='number of data loading workers (default: %(default)s)')
 parser.add_argument('--epochs', default=90, type=int, metavar='N',
                     help='number of total epochs to run')
 parser.add_argument('--start-epoch', default=0, type=int, metavar='N',
                     help='manual epoch number (useful on restarts)')
 parser.add_argument('-b', '--batch-size', default=256, type=int,
                     metavar='N',
-                    help='mini-batch size (default: 256), this is the total '
+                    help='mini-batch size (default: %(default)s), this is the total '
                          'batch size of all GPUs on the current node when '
                          'using Data Parallel or Distributed Data Parallel')
 parser.add_argument('--lr', '--learning-rate', default=0.1, type=float,
@@ -49,12 +49,12 @@ parser.add_argument('--lr', '--learning-rate', default=0.1, type=float,
 parser.add_argument('--momentum', default=0.9, type=float, metavar='M',
                     help='momentum')
 parser.add_argument('--wd', '--weight-decay', default=1e-4, type=float,
-                    metavar='W', help='weight decay (default: 1e-4)',
+                    metavar='W', help='weight decay (default: %(default)s)',
                     dest='weight_decay')
 parser.add_argument('-p', '--print-freq', default=10, type=int,
-                    metavar='N', help='print frequency (default: 10)')
+                    metavar='N', help='print frequency (default: %(default)s)')
 parser.add_argument('--resume', default='', type=str, metavar='PATH',
-                    help='path to latest checkpoint (default: none)')
+                    help='path to latest checkpoint (default: %(default)s)')
 parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
                     help='evaluate model on validation set')
 parser.add_argument('--pretrained', dest='pretrained', action='store_true',

--- a/legacy/snli/util.py
+++ b/legacy/snli/util.py
@@ -23,7 +23,7 @@ def get_args():
     parser.add_argument('--epochs', type=int, default=50,
                         help='the number of total epochs to run.')
     parser.add_argument('--batch_size', type=int, default=128,
-                        help='batch size. (default: 128)')
+                        help='batch size. (default: %(default)s)')
     parser.add_argument('--d_embed', type=int, default=100,
                         help='the size of each embedding vector.')
     parser.add_argument('--d_proj', type=int, default=300,
@@ -31,10 +31,10 @@ def get_args():
     parser.add_argument('--d_hidden', type=int, default=300,
                         help='the number of features in the hidden state.')
     parser.add_argument('--n_layers', type=int, default=1,
-                        help='the number of recurrent layers. (default: 50)')
+                        help='the number of recurrent layers. (default: %(default)s)')
     parser.add_argument('--log_every', type=int, default=50,
                         help='iteration period to output log.')
-    parser.add_argument('--lr',type=float, default=.001,
+    parser.add_argument('--lr', type=float, default=.001,
                         help='initial learning rate.')
     parser.add_argument('--dev_every', type=int, default=1000,
                         help='log period of validation results.')
@@ -51,7 +51,7 @@ def get_args():
     parser.add_argument('--train_embed', action='store_false', dest='fix_emb',
                         help='enable embedding word training.')
     parser.add_argument('--gpu', type=int, default=0,
-                        help='gpu id to use. (default: 0)')
+                        help='gpu id to use. (default: %(default)s)')
     parser.add_argument('--save_path', type=str, default='results',
                         help='save path of results.')
     parser.add_argument('--vector_cache', type=str, default=os.path.join(os.getcwd(), '.vector_cache/input_vectors.pt'),

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -73,15 +73,15 @@ def main():
     # Training settings
     parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
     parser.add_argument('--batch-size', type=int, default=64, metavar='N',
-                        help='input batch size for training (default: 64)')
+                        help='input batch size for training (default: %(default)s)')
     parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
-                        help='input batch size for testing (default: 1000)')
+                        help='input batch size for testing (default: %(default)s)')
     parser.add_argument('--epochs', type=int, default=14, metavar='N',
-                        help='number of epochs to train (default: 14)')
+                        help='number of epochs to train (default: %(default)s)')
     parser.add_argument('--lr', type=float, default=1.0, metavar='LR',
-                        help='learning rate (default: 1.0)')
+                        help='learning rate (default: %(default)s)')
     parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
-                        help='Learning rate step gamma (default: 0.7)')
+                        help='Learning rate step gamma (default: %(default)s)')
     parser.add_argument('--no-cuda', action='store_true', default=False,
                         help='disables CUDA training')
     parser.add_argument('--no-mps', action='store_true', default=False,
@@ -89,7 +89,7 @@ def main():
     parser.add_argument('--dry-run', action='store_true', default=False,
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
-                        help='random seed (default: 1)')
+                        help='random seed (default: %(default)s)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
     parser.add_argument('--save-model', action='store_true', default=False,

--- a/mnist_forward_forward/main.py
+++ b/mnist_forward_forward/main.py
@@ -92,14 +92,14 @@ if __name__ == "__main__":
         type=int,
         default=1000,
         metavar="N",
-        help="number of epochs to train (default: 1000)",
+        help="number of epochs to train (default: %(default)s)",
     )
     parser.add_argument(
         "--lr",
         type=float,
         default=0.03,
         metavar="LR",
-        help="learning rate (default: 0.03)",
+        help="learning rate (default: %(default)s)",
     )
     parser.add_argument(
         "--no_cuda", action="store_true", default=False, help="disables CUDA training"
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         "--no_mps", action="store_true", default=False, help="disables MPS training"
     )
     parser.add_argument(
-        "--seed", type=int, default=1, metavar="S", help="random seed (default: 1)"
+        "--seed", type=int, default=1, metavar="S", help="random seed (default: %(default)s)"
     )
     parser.add_argument(
         "--save_model",

--- a/mnist_hogwild/main.py
+++ b/mnist_hogwild/main.py
@@ -12,21 +12,21 @@ from train import train, test
 # Training settings
 parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
 parser.add_argument('--batch-size', type=int, default=64, metavar='N',
-                    help='input batch size for training (default: 64)')
+                    help='input batch size for training (default: %(default)s)')
 parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
-                    help='input batch size for testing (default: 1000)')
+                    help='input batch size for testing (default: %(default)s)')
 parser.add_argument('--epochs', type=int, default=10, metavar='N',
-                    help='number of epochs to train (default: 10)')
+                    help='number of epochs to train (default: %(default)s)')
 parser.add_argument('--lr', type=float, default=0.01, metavar='LR',
-                    help='learning rate (default: 0.01)')
+                    help='learning rate (default: %(default)s)')
 parser.add_argument('--momentum', type=float, default=0.5, metavar='M',
-                    help='SGD momentum (default: 0.5)')
+                    help='SGD momentum (default: %(default)s)')
 parser.add_argument('--seed', type=int, default=1, metavar='S',
-                    help='random seed (default: 1)')
+                    help='random seed (default: %(default)s)')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                     help='how many batches to wait before logging training status')
 parser.add_argument('--num-processes', type=int, default=2, metavar='N',
-                    help='how many training processes to use (default: 2)')
+                    help='how many training processes to use (default: %(default)s)')
 parser.add_argument('--cuda', action='store_true', default=False,
                     help='enables CUDA training')
 parser.add_argument('--mps', action='store_true', default=False,

--- a/mnist_rnn/main.py
+++ b/mnist_rnn/main.py
@@ -82,15 +82,15 @@ def main():
     # Training settings
     parser = argparse.ArgumentParser(description='PyTorch MNIST Example using RNN')
     parser.add_argument('--batch-size', type=int, default=64, metavar='N',
-                        help='input batch size for training (default: 64)')
+                        help='input batch size for training (default: %(default)s)')
     parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
-                        help='input batch size for testing (default: 1000)')
+                        help='input batch size for testing (default: %(default)s)')
     parser.add_argument('--epochs', type=int, default=14, metavar='N',
-                        help='number of epochs to train (default: 14)')
+                        help='number of epochs to train (default: %(default)s)')
     parser.add_argument('--lr', type=float, default=0.1, metavar='LR',
-                        help='learning rate (default: 0.1)')
+                        help='learning rate (default: %(default)s)')
     parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
-                        help='learning rate step gamma (default: 0.7)')
+                        help='learning rate step gamma (default: %(default)s)')
     parser.add_argument('--cuda', action='store_true', default=False,
                         help='enables CUDA training')
     parser.add_argument('--mps', action="store_true", default=False,
@@ -98,7 +98,7 @@ def main():
     parser.add_argument('--dry-run', action='store_true', default=False,
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
-                        help='random seed (default: 1)')
+                        help='random seed (default: %(default)s)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
     parser.add_argument('--save-model', action='store_true', default=False,

--- a/reinforcement_learning/actor_critic.py
+++ b/reinforcement_learning/actor_critic.py
@@ -14,13 +14,13 @@ from torch.distributions import Categorical
 
 parser = argparse.ArgumentParser(description='PyTorch actor-critic example')
 parser.add_argument('--gamma', type=float, default=0.99, metavar='G',
-                    help='discount factor (default: 0.99)')
+                    help='discount factor (default: %(default)s)')
 parser.add_argument('--seed', type=int, default=543, metavar='N',
-                    help='random seed (default: 543)')
+                    help='random seed (default: %(default)s)')
 parser.add_argument('--render', action='store_true',
                     help='render the environment')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',
-                    help='interval between training status logs (default: 10)')
+                    help='interval between training status logs (default: %(default)s)')
 args = parser.parse_args()
 
 

--- a/reinforcement_learning/reinforce.py
+++ b/reinforcement_learning/reinforce.py
@@ -12,13 +12,13 @@ from torch.distributions import Categorical
 
 parser = argparse.ArgumentParser(description='PyTorch REINFORCE example')
 parser.add_argument('--gamma', type=float, default=0.99, metavar='G',
-                    help='discount factor (default: 0.99)')
+                    help='discount factor (default: %(default)s)')
 parser.add_argument('--seed', type=int, default=543, metavar='N',
-                    help='random seed (default: 543)')
+                    help='random seed (default: %(default)s)')
 parser.add_argument('--render', action='store_true',
                     help='render the environment')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',
-                    help='interval between training status logs (default: 10)')
+                    help='interval between training status logs (default: %(default)s)')
 args = parser.parse_args()
 
 

--- a/siamese_network/main.py
+++ b/siamese_network/main.py
@@ -238,15 +238,15 @@ def main():
     # Training settings
     parser = argparse.ArgumentParser(description='PyTorch Siamese network Example')
     parser.add_argument('--batch-size', type=int, default=64, metavar='N',
-                        help='input batch size for training (default: 64)')
+                        help='input batch size for training (default: %(default)s)')
     parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
-                        help='input batch size for testing (default: 1000)')
+                        help='input batch size for testing (default: %(default)s)')
     parser.add_argument('--epochs', type=int, default=14, metavar='N',
-                        help='number of epochs to train (default: 14)')
+                        help='number of epochs to train (default: %(default)s)')
     parser.add_argument('--lr', type=float, default=1.0, metavar='LR',
-                        help='learning rate (default: 1.0)')
+                        help='learning rate (default: %(default)s)')
     parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
-                        help='Learning rate step gamma (default: 0.7)')
+                        help='Learning rate step gamma (default: %(default)s)')
     parser.add_argument('--no-cuda', action='store_true', default=False,
                         help='disables CUDA training')
     parser.add_argument('--no-mps', action='store_true', default=False,
@@ -254,7 +254,7 @@ def main():
     parser.add_argument('--dry-run', action='store_true', default=False,
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
-                        help='random seed (default: 1)')
+                        help='random seed (default: %(default)s)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
     parser.add_argument('--save-model', action='store_true', default=False,

--- a/vae/main.py
+++ b/vae/main.py
@@ -10,15 +10,15 @@ from torchvision.utils import save_image
 
 parser = argparse.ArgumentParser(description='VAE MNIST Example')
 parser.add_argument('--batch-size', type=int, default=128, metavar='N',
-                    help='input batch size for training (default: 128)')
+                    help='input batch size for training (default: %(default)s)')
 parser.add_argument('--epochs', type=int, default=10, metavar='N',
-                    help='number of epochs to train (default: 10)')
+                    help='number of epochs to train (default: %(default)s)')
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
 parser.add_argument('--no-mps', action='store_true', default=False,
-                        help='disables macOS GPU training')
+                    help='disables macOS GPU training')
 parser.add_argument('--seed', type=int, default=1, metavar='S',
-                    help='random seed (default: 1)')
+                    help='random seed (default: %(default)s)')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                     help='how many batches to wait before logging training status')
 args = parser.parse_args()

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -24,7 +24,7 @@ parser.add_argument('--seed', type=int, default=1111,
 parser.add_argument('--cuda', action='store_true',
                     help='use CUDA')
 parser.add_argument('--mps', action='store_true', default=False,
-                        help='enables macOS GPU training')
+                    help='enables macOS GPU training')
 parser.add_argument('--temperature', type=float, default=1.0,
                     help='temperature - higher will increase diversity')
 parser.add_argument('--log-interval', type=int, default=100,
@@ -39,7 +39,7 @@ if torch.cuda.is_available():
 if torch.backends.mps.is_available():
     if not args.mps:
         print("WARNING: You have mps device, to enable macOS GPU run with --mps.")
-        
+
 use_mps = args.mps and torch.backends.mps.is_available()
 if args.cuda:
     device = torch.device("cuda")

--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -40,7 +40,7 @@ parser.add_argument('--seed', type=int, default=1111,
 parser.add_argument('--cuda', action='store_true', default=False,
                     help='use CUDA')
 parser.add_argument('--mps', action='store_true', default=False,
-                        help='enables macOS GPU training')
+                    help='enables macOS GPU training')
 parser.add_argument('--log-interval', type=int, default=200, metavar='N',
                     help='report interval')
 parser.add_argument('--save', type=str, default='model.pt',


### PR DESCRIPTION
Replaces the hardcoded values in the arguments' parser help strings with `%(default)s` so that they're always in sync. See documentation at https://docs.python.org/3/library/argparse.html#help
Makes PR #1281 no longer necessary.