### PR TITLE
Fix invalid characters in filename in neural_style.py (line 119 in train function)

### DIFF
--- a/fast_neural_style/neural_style/neural_style.py
+++ b/fast_neural_style/neural_style/neural_style.py
@@ -116,8 +116,8 @@ def train(args):
 
     # save model
     transformer.eval().cpu()
-    save_model_filename = "epoch_" + str(args.epochs) + "_" + str(time.ctime()).replace(' ', '_') + "_" + str(
-        args.content_weight) + "_" + str(args.style_weight) + ".model"
+    timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
+    save_model_filename = f"epoch_{args.epochs}_{timestamp}_{args.content_weight}_{args.style_weight}.model"
     save_model_path = os.path.join(args.save_model_dir, save_model_filename)
     torch.save(transformer.state_dict(), save_model_path)
 


### PR DESCRIPTION
Replaced colon (:) in the timestamp to ensure the file can be saved correctly on Windows. The change was made at line 119 of the train function in neural_style.py.