### PR TITLE
Fix python failing tests

### DIFF
--- a/.github/workflows/main_python.yml
+++ b/.github/workflows/main_python.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: '3.10'
     - name: Install PyTorch
       run: |
         python -m pip install --upgrade pip

--- a/dcgan/requirements.txt
+++ b/dcgan/requirements.txt
@@ -1,3 +1,3 @@
 torch
-torchvision
+torchvision==0.20.0
 lmdb

--- a/gat/requirements.txt
+++ b/gat/requirements.txt
@@ -1,3 +1,3 @@
 torch
 requests
-numpy
+numpy<2

--- a/gcn/requirements.txt
+++ b/gcn/requirements.txt
@@ -1,4 +1,4 @@
 torch
-torchvision
+torchvision==0.20.0
 requests
-numpy
+numpy<2

--- a/imagenet/requirements.txt
+++ b/imagenet/requirements.txt
@@ -1,2 +1,2 @@
 torch
-torchvision
+torchvision==0.20.0

--- a/language_translation/requirements.txt
+++ b/language_translation/requirements.txt
@@ -1,5 +1,5 @@
 torch
 torchtext
-torchdata
+torchdata==0.9.0
 spacy
 portalocker

--- a/mnist/requirements.txt
+++ b/mnist/requirements.txt
@@ -1,2 +1,2 @@
 torch
-torchvision
+torchvision==0.20.0

--- a/mnist_forward_forward/requirements.txt
+++ b/mnist_forward_forward/requirements.txt
@@ -1,2 +1,2 @@
 torch
-torchvision
+torchvision==0.20.0

--- a/mnist_hogwild/requirements.txt
+++ b/mnist_hogwild/requirements.txt
@@ -1,2 +1,2 @@
 torch
-torchvision
+torchvision==0.20.0

--- a/mnist_rnn/requirements.txt
+++ b/mnist_rnn/requirements.txt
@@ -1,2 +1,2 @@
 torch
-torchvision
+torchvision==0.20.0

--- a/siamese_network/requirements.txt
+++ b/siamese_network/requirements.txt
@@ -1,2 +1,2 @@
 torch
-torchvision
+torchvision==0.20.0

--- a/vae/requirements.txt
+++ b/vae/requirements.txt
@@ -1,4 +1,4 @@
 torch
-torchvision
+torchvision==0.20.0
 tqdm
 six


### PR DESCRIPTION
Summary:
Python tests are failing because of module/version incompatibilities. This change is pulling out the failing tests issue from 
https://github.com/pytorch/examples/pull/1297 into a separate commit so that the 2 changes can be committed independently.

1. Pick specific version of torchvision to fix dependency errors
2. Pin numpy to be below version 2.
3. Update Python version in python tests.

Test Plan:
Tested locally.