### PR TITLE
Fixed "--help" output in README.md

### DIFF
--- a/mnist_hogwild/README.md
+++ b/mnist_hogwild/README.md
@@ -10,17 +10,16 @@ The main.py script accepts the following arguments:
 ```bash
 optional arguments:
   -h, --help            show this help message and exit
-  --batch_size          input batch_size for training (default:64)
-  --testing_batch_size  input batch size for testing (default: 1000)
-  --epochs EPOCHS       number of epochs to train (default: 1000)
-  --lr LR               learning rate (default: 0.03)
+  --batch-size          input batch_size for training (default: 64)
+  --test-batch-size     input batch size for testing (default: 1000)
+  --epochs EPOCHS       number of epochs to train (default: 10)
+  --lr LR               learning rate (default: 0.01)
   --momentum            SGD momentum (default: 0.5)
   --seed SEED           random seed (default: 1)
-  --mps                 enables macos GPU training
-  --save_model          For saving the current Model
-  --log_interval        how many batches to wait before logging training status
-  --num_process         how many training processes to use (default: 2)
+  --save_model          save the trained model to state_dict
+  --log-interval        how many batches to wait before logging training status (default: 10)
+  --num-processes       how many training processes to use (default: 2)
   --cuda                enables CUDA training
+  --mps                 enables macos GPU training
   --dry-run             quickly check a single pass
-  --save-model          For Saving the current Model
 ```


### PR DESCRIPTION
Updated arguments to match what main.py is looking for. Fixed incorrectly listed defaults, removed duplicate "--save-model", copied "--save_model" description from main.py.