### PR TITLE
Fix doc build

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -21,7 +21,6 @@ jobs:
     - name: Dependencies
       run: |
         echo `python3 --version`
-        sudo apt-get install -y python-setuptools
         sudo apt-get install -y python3-sphinx
         python3 -m pip install --upgrade pip
         python3 -m pip install setuptools


### PR DESCRIPTION
python-setuptools is causing the doc build to fail: https://github.com/pytorch/examples/actions/runs/13041502252/job/36384208905
I don't think this dependency is even needed for the doc build so checking here. 