### PR TITLE
Bump torchvision to 0.21.0

### DIFF
--- a/mnist/requirements.txt
+++ b/mnist/requirements.txt
@@ -1,2 +1,2 @@
 torch
-torchvision==0.20.0
+torchvision==0.21.0


### PR DESCRIPTION
When I tried this example on a fresh install (OSX Python, deployed by Brew) I got the following error:

```
% pip install -r requirements.txt
ERROR: Ignored the following yanked versions: 0.1.6, 0.1.7, 0.1.8, 0.1.9, 0.2.0, 0.2.1, 0.2.2, 0.2.2.post2, 0.2.2.post3
ERROR: Could not find a version that satisfies the requirement torchvision==0.20.0 (from versions: 0.21.0)
ERROR: No matching distribution found for torchvision==0.20.0
```

When I bumped it to v0.21.0, the error went away.

I *think* this is a harmless PR. If I'm mistaken, please reject.