### PR TITLE
Lock to numpy 1.23.5 for reinforcement_learning to avoid removed np.bool

### DIFF
--- a/reinforcement_learning/requirements.txt
+++ b/reinforcement_learning/requirements.txt
@@ -1,4 +1,4 @@
 torch
-numpy
+numpy==1.23.5
 gym
 pygame


### PR DESCRIPTION
The gym library used in the reinforcement_learning example uses np.bool which is deprecated in numpy 1.20 and removed in numpy 1.24.  This is further complicated by gym itself being deprecated and not accepting updates that might fix the problem at its source; see https://github.com/openai/gym/pull/3258.

Fixed by locking the numpy version for this example to 1.23.5.