### PR TITLE
Fixed install_deps so that it happens before each test run + checking for the deps that are required separately

### DIFF
--- a/.github/workflows/main_python.yml
+++ b/.github/workflows/main_python.yml
@@ -30,7 +30,7 @@ jobs:
         # pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
     - name: Run Tests
       run: |
-        ./run_python_examples.sh "install_deps,run_all,clean"
+        ./run_python_examples.sh "run_all,clean"
     - name: Open issue on failure
       if: ${{ failure() && github.event_name  == 'schedule' }}
       uses: rishabhgupta/git-action-issue@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,12 +38,11 @@ If you're new, we encourage you to take a look at issues tagged with [good first
 ## For bug fixes
 
 1. Fork the repo and create your branch from `main`.
-2. Make sure you have a GPU-enabled machine, either locally or in the cloud. `g4dn.4xlarge` is a good starting point on AWS.
-3. Make your code change.
-4. First, install all dependencies with `./run_python_examples.sh "install_deps"`.
-5. Then, make sure that `./run_python_examples.sh` passes locally by running the script end to end.
-6. If you haven't already, complete the Contributor License Agreement ("CLA").
-7. Address any feedback in code review promptly.
+1. Make sure you have a GPU-enabled machine, either locally or in the cloud. `g4dn.4xlarge` is a good starting point on AWS.
+1. Make your code change.
+1. Then, make sure that `./run_python_examples.sh` passes locally by running the script end to end.
+1. If you haven't already, complete the Contributor License Agreement ("CLA").
+1. Address any feedback in code review promptly.
 
 ## Contributor License Agreement ("CLA")
 

--- a/run_distributed_examples.sh
+++ b/run_distributed_examples.sh
@@ -6,8 +6,8 @@
 #
 # Optionally specify a comma separated list of examples to run.
 # can be run as:
-# ./run_python_examples.sh "install_deps,run_all,clean"
-# to pip install dependencies (other than pytorch), run all examples, and remove temporary/changed data files.
+# ./run_python_examples.sh "run_all,clean"
+# run all examples, and remove temporary/changed data files.
 # Expects pytorch, torchvision to be installed.
 
 BASE_DIR="$(pwd)/$(dirname $0)"

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -6,8 +6,8 @@
 #
 # Optionally specify a comma separated list of examples to run.
 # can be run as:
-# ./run_python_examples.sh "install_deps,run_all,clean"
-# to pip install dependencies (other than pytorch), run all examples, and remove temporary/changed data files.
+# ./run_python_examples.sh "run_all,clean"
+# run all examples, and remove temporary/changed data files.
 # Expects pytorch, torchvision to be installed.
 
 BASE_DIR="$(pwd)/$(dirname $0)"

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -16,6 +16,27 @@ DEBUG=${DEBUG:-false}
 BASE_DIR="$(pwd)/$(dirname $0)"
 source $BASE_DIR/utils.sh
 
+echo "] Running Python examples"
+# Check if required packages are installed
+echo "Checking for required packages..."
+if ! pip list | grep -q "^torch "; then
+  echo "torch is not installed. Please install PyTorch."
+  exit 1
+fi
+
+if ! pip list | grep -q "^torchvision "; then
+  echo "torchvision is not installed. Please install torchvision."
+  exit 1
+fi
+
+if ! pip list | grep -q "^Pillow "; then
+  echo "Pillow is not installed. Please install Pillow."
+  exit 1
+fi
+
+echo "All required packages are installed!"
+
+echo "Checking CUDA availability"
 USE_CUDA=$(python -c "import torchvision, torch; print(torch.cuda.is_available())")
 case $USE_CUDA in
   "True")

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -239,9 +239,11 @@ if [ "" == "$EXAMPLES" ]; then
 else
   for i in $(echo $EXAMPLES | sed "s/,/ /g")
   do
+    echo "==============="
     echo "Starting $i"
     $i
     echo "Finished $i, status $?"
+    echo "==============="
   done
 fi
 

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+set -eo pipefail
+DEBUG=${DEBUG:-false}
+[[ $DEBUG == true ]] && set -x
 #
 # This script runs through the code in each of the python examples.
 # The purpose is just as an integration test, not to actually train models in any meaningful way.

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -19,17 +19,17 @@ source $BASE_DIR/utils.sh
 echo "] Running Python examples"
 # Check if required packages are installed
 echo "Checking for required packages..."
-if ! pip list | grep -q "^torch "; then
+if ! pip list | grep -q "^torch"; then
   echo "torch is not installed. Please install PyTorch."
   exit 1
 fi
 
-if ! pip list | grep -q "^torchvision "; then
+if ! pip list | grep -q "^torchvision"; then
   echo "torchvision is not installed. Please install torchvision."
   exit 1
 fi
 
-if ! pip list | grep -q "^Pillow "; then
+if ! pip list | grep -q "^Pillow"; then
   echo "Pillow is not installed. Please install Pillow."
   exit 1
 fi

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -19,17 +19,17 @@ source $BASE_DIR/utils.sh
 echo "] Running Python examples"
 # Check if required packages are installed
 echo "Checking for required packages..."
-if ! pip list | grep -q "^torch"; then
+if ! pip show torch; then
   echo "torch is not installed. Please install PyTorch."
   exit 1
 fi
 
-if ! pip list | grep -q "^torchvision"; then
+if ! pip show torchvision; then
   echo "torchvision is not installed. Please install torchvision."
   exit 1
 fi
 
-if ! pip list | grep -q "^Pillow"; then
+if ! pip show pillow; then
   echo "Pillow is not installed. Please install Pillow."
   exit 1
 fi

--- a/utils.sh
+++ b/utils.sh
@@ -22,7 +22,8 @@ function error() {
 }
 
 function install_deps() {
-  echo "installing requirements"
+  echo "] installing requirements"
+  [[ -f requirements.txt ]] || { error "requirements.txt not found; skipping"; return; }
   cat requirements.txt | \
     sort -u | \
     # testing the installed version of torch, so don't pip install it.
@@ -35,5 +36,5 @@ function start() {
   EXAMPLE=${FUNCNAME[1]}
   cd $BASE_DIR/$EXAMPLE
   install_deps
-  echo "Running example: $EXAMPLE"
+  echo "] Running example: $EXAMPLE"
 }

--- a/utils.sh
+++ b/utils.sh
@@ -25,12 +25,12 @@ function install_deps() {
   EXAMPLE_NAME=$1
   echo "] $EXAMPLE_NAME: installing requirements"
   [[ -f requirements.txt ]] || { error "requirements.txt not found; skipping"; return; }
-  cat requirements.txt | \
-    sort -u | \
+  for req in $(cat requirements.txt); do
     # testing the installed version of torch, so don't pip install it.
-    grep -vE '^torch$' | \
-    pip install -r /dev/stdin || \
-    { error "failed to install dependencies"; exit 1; }
+    if [[ "$req" != "torch" ]]; then
+      pip install "$req" || { error "failed to install $req"; exit 1; }
+    fi
+  done
 }
 
 function start() {

--- a/utils.sh
+++ b/utils.sh
@@ -24,7 +24,7 @@ function error() {
 function install_deps() {
   EXAMPLE_NAME=$1
   echo "] $EXAMPLE_NAME: installing requirements"
-  [[ -f requirements.txt ]] || { error "requirements.txt not found; skipping"; return; }
+  [[ -f requirements.txt ]] || return
   for req in $(cat requirements.txt); do
     # testing the installed version of torch, so don't pip install it.
     if [[ "$req" != "torch" ]]; then

--- a/utils.sh
+++ b/utils.sh
@@ -23,7 +23,7 @@ function error() {
 
 function install_deps() {
   echo "installing requirements"
-  cat $BASE_DIR/*/requirements.txt | \
+  cat requirements.txt | \
     sort -u | \
     # testing the installed version of torch, so don't pip install it.
     grep -vE '^torch$' | \
@@ -34,5 +34,6 @@ function install_deps() {
 function start() {
   EXAMPLE=${FUNCNAME[1]}
   cd $BASE_DIR/$EXAMPLE
+  install_deps
   echo "Running example: $EXAMPLE"
 }

--- a/utils.sh
+++ b/utils.sh
@@ -22,7 +22,8 @@ function error() {
 }
 
 function install_deps() {
-  echo "] installing requirements"
+  EXAMPLE_NAME=$1
+  echo "] $EXAMPLE_NAME: installing requirements"
   [[ -f requirements.txt ]] || { error "requirements.txt not found; skipping"; return; }
   cat requirements.txt | \
     sort -u | \
@@ -33,8 +34,8 @@ function install_deps() {
 }
 
 function start() {
-  EXAMPLE=${FUNCNAME[1]}
-  cd $BASE_DIR/$EXAMPLE
-  install_deps
-  echo "] Running example: $EXAMPLE"
+  EXAMPLE_NAME=${FUNCNAME[1]}
+  cd $BASE_DIR/$EXAMPLE_NAME
+  install_deps $EXAMPLE_NAME
+  echo "] $EXAMPLE_NAME: running"
 }


### PR DESCRIPTION
Reasoning for the PR: The sh scripts don't do install_deps, so they fail. Each folder has a requirements file, so we should be installing the specific reqs before each test run.

Also, checks should be done to make sure torch and torchvision are installed. Pillow too as it's absence causes a failure doing the CUDA check.