### PR TITLE
Update doc-build.yml and requirements for documentation build

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -17,14 +17,16 @@ jobs:
         python-version: [3.9]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Dependencies
       run: |
+        export DEBIAN_FRONTEND=noninteractive
+        sudo apt-get update
+        sudo apt install -y git python3-venv make
         echo `python3 --version`
-        sudo apt-get install -y python-setuptools
-        sudo apt-get install -y python3-sphinx
-        python3 -m pip install --upgrade pip
-        python3 -m pip install setuptools
+        python3 -m venv venv 
+        source venv/bin/activate 
+        pip install --upgrade pip setuptools 
       id: build
     - name: Build the docset
       run: | 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx
-# torch
-# PyTorch Theme
+
+sphinx==5.3.0
+#Pinned versions: 5.3.0
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinx-panels


### PR DESCRIPTION
Update doc-build.yml to fix https://github.com/pytorch/examples/actions/runs/14716493656/job/41300982937 job

- Upgrade actions/checkout from v2 to v4
- Use venv to create the virtual env
- Pin sphinx version to 5.3.0 in requirements.txt with descriptions

CC: @msaroufim 