### PR TITLE
This PR Improve docs build ci 

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         export DEBIAN_FRONTEND=noninteractive
         sudo apt-get update
-        sudo apt install -y git python3-venv make
+        sudo apt install -y git python3-venv make python3-setuptools
         echo `python3 --version`
         python3 -m venv venv 
         source venv/bin/activate 
@@ -30,6 +30,7 @@ jobs:
       id: build
     - name: Build the docset
       run: | 
+        source ../venv/bin/activate 
         cd docs
         pip install -r requirements.txt
         make html 

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -21,7 +21,6 @@ jobs:
       id: build
     - name: Build the docset
       run: | 
-        source ../venv/bin/activate 
         cd docs
         pip install -r requirements.txt
         make html 

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -18,15 +18,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Dependencies
-      run: |
-        export DEBIAN_FRONTEND=noninteractive
-        sudo apt-get update
-        sudo apt install -y git python3-venv make python3-setuptools
-        echo `python3 --version`
-        python3 -m venv venv 
-        source venv/bin/activate 
-        pip install --upgrade pip setuptools 
       id: build
     - name: Build the docset
       run: | 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,6 @@ html_theme_path = [pytorch_sphinx_theme.get_html_theme_path()]
 # so a file named "default.css" will overwrite the builtin "default.css".
 
 html_static_path = ["_static"]
-
 panels_add_fontawesome_latex = True
 
 html_theme_options = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,8 +41,7 @@ release = "1.11"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.napoleon", "sphinx.ext.autodoc", 'sphinx_panels']
-panels_add_bootstrap_css = False
+extensions = ["sphinx.ext.napoleon", "sphinx.ext.autodoc", "sphinx_panels"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -66,6 +65,7 @@ html_theme_path = [pytorch_sphinx_theme.get_html_theme_path()]
 # so a file named "default.css" will overwrite the builtin "default.css".
 
 html_static_path = ["_static"]
+html_css_files = [] # avoid undefined errors
 panels_add_fontawesome_latex = True
 
 html_theme_options = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,7 @@ html_theme_path = [pytorch_sphinx_theme.get_html_theme_path()]
 # so a file named "default.css" will overwrite the builtin "default.css".
 
 html_static_path = ["_static"]
-html_css_files = [] # avoid undefined errors
+
 panels_add_fontawesome_latex = True
 
 html_theme_options = {


### PR DESCRIPTION
This PR Improve docs build ci


**Changes:**
- removed redundant dependencies (`git`, `make`, `python3-venv`) from the GitHub Actions workflow, as they are preinstalled on `ubuntu-latest` runners. 
- Removed deprecated `panels_add_bootstrap_css`
- Created `_static` directory to resolve warnings.

**Testing:**
- Verified locally with `make html` (no errors/warnings).