### PR TITLE
Use torch.accelerator API in VAE example 

### DIFF
--- a/vae/README.md
+++ b/vae/README.md
@@ -14,8 +14,7 @@ The main.py script accepts the following arguments:
 optional arguments:
   --batch-size		input batch size for training (default: 128)
   --epochs		number of epochs to train (default: 10)
-  --no-cuda		enables CUDA training
-  --mps         enables GPU on macOS
+  --accel		  use accelerator
   --seed		random seed (default: 1)
   --log-interval	how many batches to wait before logging training status
 ```

--- a/vae/README.md
+++ b/vae/README.md
@@ -8,13 +8,12 @@ pip install -r requirements.txt
 python main.py
 ```
 
-The main.py script accepts the following arguments:
+The main.py script accepts the following optional arguments:
 
 ```bash
-optional arguments:
-  --batch-size		input batch size for training (default: 128)
-  --epochs		number of epochs to train (default: 10)
-  --accel		  use accelerator
-  --seed		random seed (default: 1)
-  --log-interval	how many batches to wait before logging training status
+--batch-size            input batch size for training (default: 128)
+--epochs                number of epochs to train (default: 10)
+--accel                 use accelerator
+--seed                  random seed (default: 1)
+--log-interval	        how many batches to wait before logging training status
 ```

--- a/vae/requirements.txt
+++ b/vae/requirements.txt
@@ -1,4 +1,4 @@
 torch
-torchvision==0.20.0
+torchvision
 tqdm
 six


### PR DESCRIPTION
Refactor VAE example to utilize torch.accelerator API. torch.accelerator API allows to abstract some of the accelerator specifics in the user scripts. By leveraging this API, the code becomes more adaptable to various hardware accelerators.

CC: @msaroufim, @malfet