### PR TITLE
Restore default CI configuration for VAE and Siamese examples using accelerator API

### DIFF
--- a/siamese_network/README.md
+++ b/siamese_network/README.md
@@ -28,7 +28,9 @@ Optionally, you can add the following arguments to customize your execution.
 --save-model            Saving the current Model
 ```
 
-To run the example, execute:
+If a hardware accelerator device is detected, the example will execute on the accelerator; otherwise, it will run on the CPU.
+
+To force execution on the CPU, use `--no-accel` command line argument:
 
 ```bash
 python main.py --no-accel

--- a/siamese_network/README.md
+++ b/siamese_network/README.md
@@ -21,17 +21,19 @@ Optionally, you can add the following arguments to customize your execution.
 --epochs                number of epochs to train (default: 14)
 --lr                    learning rate (default: 1.0)
 --gamma                 learning rate step gamma (default: 0.7)
---accel                 use accelerator
+--no-accel              disables accelerator
 --dry-run               quickly check a single pass
 --seed                  random seed (default: 1)
 --log-interval          how many batches to wait before logging training status
 --save-model            Saving the current Model
 ```
 
-To execute in an GPU, add the --accel argument to the command. For example:
+If an accelerator is detected, the example will be executed on the accelerator by default; otherwise,it will runon the CPU
+
+To disable the accelerator option, add the --no-accel argument to the command. For example:
 
 ```bash
-python main.py --accel
+python main.py --no-accel
 ```
 
-This command will execute the example on the detected GPU.
+This command will execute the example on the CPU even if your system successfully detects an XPU.

--- a/siamese_network/README.md
+++ b/siamese_network/README.md
@@ -28,7 +28,7 @@ Optionally, you can add the following arguments to customize your execution.
 --save-model            Saving the current Model
 ```
 
-If an accelerator is detected, the example will be executed on the accelerator by default; otherwise,it will runon the CPU
+If an accelerator is detected, the example will be executed on the accelerator by default; otherwise,it will run on the CPU
 
 To disable the accelerator option, add the --no-accel argument to the command. For example:
 
@@ -36,4 +36,4 @@ To disable the accelerator option, add the --no-accel argument to the command. F
 python main.py --no-accel
 ```
 
-This command will execute the example on the CPU even if your system successfully detects an XPU.
+This command will execute the example on the CPU even if your system successfully detects an accelerator.

--- a/siamese_network/README.md
+++ b/siamese_network/README.md
@@ -8,11 +8,27 @@ This implementation varies from FaceNet as we use the `ResNet-18` model from
 [Deep Residual Learning for Image Recognition](https://arxiv.org/pdf/1512.03385.pdf) as our feature extractor.
 In addition, we aren't using `TripletLoss` as the MNIST dataset is simple, so `BCELoss` can do the trick.
 
+### Usage
+
+Install the required dependencies:
 ```bash
 pip install -r requirements.txt
+```
+
+To run the example, execute:
+```bahs
 python main.py
 # CUDA_VISIBLE_DEVICES=2 python main.py  # to specify GPU id to ex. 2
 ```
+
+If a hardware accelerator device is detected, the example will execute on the accelerator; otherwise, it will run on the CPU.
+
+To force execution on the CPU, use `--no-accel` command line argument:
+
+```bash
+python main.py --no-accel
+```
+
 Optionally, you can add the following arguments to customize your execution.
 
 ```bash
@@ -26,12 +42,4 @@ Optionally, you can add the following arguments to customize your execution.
 --seed                  random seed (default: 1)
 --log-interval          how many batches to wait before logging training status
 --save-model            Saving the current Model
-```
-
-If a hardware accelerator device is detected, the example will execute on the accelerator; otherwise, it will run on the CPU.
-
-To force execution on the CPU, use `--no-accel` command line argument:
-
-```bash
-python main.py --no-accel
 ```

--- a/siamese_network/README.md
+++ b/siamese_network/README.md
@@ -33,5 +33,3 @@ To run the example, execute:
 ```bash
 python main.py --no-accel
 ```
-
-This command will execute the example on the CPU even if your system successfully detects an accelerator.

--- a/siamese_network/README.md
+++ b/siamese_network/README.md
@@ -28,9 +28,7 @@ Optionally, you can add the following arguments to customize your execution.
 --save-model            Saving the current Model
 ```
 
-If an accelerator is detected, the example will be executed on the accelerator by default; otherwise,it will run on the CPU
-
-To disable the accelerator option, add the --no-accel argument to the command. For example:
+To run the example, execute:
 
 ```bash
 python main.py --no-accel

--- a/siamese_network/main.py
+++ b/siamese_network/main.py
@@ -263,8 +263,6 @@ def main():
 
     torch.manual_seed(args.seed)
 
-    if args.no_accel and torch.accelerator.is_available():
-        print("WARNING: accelerator is available, remove --no-accel to enable accelerator")
 
     if use_accel:
         device = torch.accelerator.current_accelerator()

--- a/siamese_network/main.py
+++ b/siamese_network/main.py
@@ -247,8 +247,8 @@ def main():
                         help='learning rate (default: 1.0)')
     parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
                         help='Learning rate step gamma (default: 0.7)')
-    parser.add_argument('--accel', action='store_true', 
-                    help='use accelerator')
+    parser.add_argument('--no-accel', action='store_true', 
+                    help='disables accelerator')
     parser.add_argument('--dry-run', action='store_true', default=False,
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
@@ -258,16 +258,15 @@ def main():
     parser.add_argument('--save-model', action='store_true', default=False,
                         help='For Saving the current Model')
     args = parser.parse_args()
+    
+    use_accel = not args.no_accel and torch.accelerator.is_available()
 
     torch.manual_seed(args.seed)
 
-    if args.accel and not torch.accelerator.is_available():
-        print("ERROR: accelerator is not available, try running on CPU")
-        sys.exit(1)
-    if not args.accel and torch.accelerator.is_available():
-        print("WARNING: accelerator is available, run with --accel to enable it")
+    if args.no_accel and torch.accelerator.is_available():
+        print("WARNING: accelerator is available, remove --no-accel to enable accelerator")
 
-    if args.accel:
+    if use_accel:
         device = torch.accelerator.current_accelerator()
     else:
         device = torch.device("cpu")
@@ -276,12 +275,12 @@ def main():
 
     train_kwargs = {'batch_size': args.batch_size}
     test_kwargs = {'batch_size': args.test_batch_size}
-    if device=="cuda":
-        cuda_kwargs = {'num_workers': 1,
+    if use_accel:
+        accel_kwargs = {'num_workers': 1,
                        'pin_memory': True,
                        'shuffle': True}
-        train_kwargs.update(cuda_kwargs)
-        test_kwargs.update(cuda_kwargs)
+        train_kwargs.update(accel_kwargs)
+        test_kwargs.update(accel_kwargs)
 
     train_dataset = APP_MATCHER('../data', train=True, download=True)
     test_dataset = APP_MATCHER('../data', train=False)

--- a/vae/README.md
+++ b/vae/README.md
@@ -17,3 +17,11 @@ The main.py script accepts the following optional arguments:
 --seed                  random seed (default: 1)
 --log-interval	        how many batches to wait before logging training status
 ```
+
+If a hardware accelerator device is detected, the example will execute on the accelerator; otherwise, it will run on the CPU.
+
+To force execution on the CPU, use `--no-accel` command line argument:
+
+```bash
+python main.py --no-accel
+```

--- a/vae/README.md
+++ b/vae/README.md
@@ -3,9 +3,23 @@
 This is an improved implementation of the paper [Auto-Encoding Variational Bayes](http://arxiv.org/abs/1312.6114) by Kingma and Welling.
 It uses ReLUs and the adam optimizer, instead of sigmoids and adagrad. These changes make the network converge much faster.
 
+### Usage
+Install the required dependencies:
 ```bash
 pip install -r requirements.txt
+```
+
+To run the example, execute:
+```bash
 python main.py
+```
+
+If a hardware accelerator device is detected, the example will execute on the accelerator; otherwise, it will run on the CPU.
+
+To force execution on the CPU, use `--no-accel` command line argument:
+
+```bash
+python main.py --no-accel
 ```
 
 The main.py script accepts the following optional arguments:
@@ -18,10 +32,3 @@ The main.py script accepts the following optional arguments:
 --log-interval	        how many batches to wait before logging training status
 ```
 
-If a hardware accelerator device is detected, the example will execute on the accelerator; otherwise, it will run on the CPU.
-
-To force execution on the CPU, use `--no-accel` command line argument:
-
-```bash
-python main.py --no-accel
-```

--- a/vae/README.md
+++ b/vae/README.md
@@ -13,7 +13,7 @@ The main.py script accepts the following optional arguments:
 ```bash
 --batch-size            input batch size for training (default: 128)
 --epochs                number of epochs to train (default: 10)
---accel                 use accelerator
+--no-accel              disables accelerator
 --seed                  random seed (default: 1)
 --log-interval	        how many batches to wait before logging training status
 ```

--- a/vae/main.py
+++ b/vae/main.py
@@ -13,31 +13,29 @@ parser.add_argument('--batch-size', type=int, default=128, metavar='N',
                     help='input batch size for training (default: 128)')
 parser.add_argument('--epochs', type=int, default=10, metavar='N',
                     help='number of epochs to train (default: 10)')
-parser.add_argument('--accel', action='store_true', 
-                    help='use accelerator')
+parser.add_argument('--no-accel', action='store_true', 
+                    help='disables accelerator')
 parser.add_argument('--seed', type=int, default=1, metavar='S',
                     help='random seed (default: 1)')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                     help='how many batches to wait before logging training status')
 args = parser.parse_args()
 
+use_accel = not args.no_accel and torch.accelerator.is_available()
 
 torch.manual_seed(args.seed)
 
-if args.accel and not torch.accelerator.is_available():
-    print("ERROR: accelerator is not available, try running on CPU")
-    sys.exit(1)
-if not args.accel and torch.accelerator.is_available():
-         print("WARNING: accelerator is available, run with --accel to enable it")
+if args.no_accel and torch.accelerator.is_available():
+    print("WARNING: accelerator is available, remove --no-accel to enable accelerator")
 
-if args.accel:
+if use_accel:
     device = torch.accelerator.current_accelerator()
 else:
     device = torch.device("cpu")
 
 print(f"Using device: {device}")
 
-kwargs = {'num_workers': 1, 'pin_memory': True} if device=="cuda" else {}
+kwargs = {'num_workers': 1, 'pin_memory': True} if use_accel else {}
 train_loader = torch.utils.data.DataLoader(
     datasets.MNIST('../data', train=True, download=True,
                    transform=transforms.ToTensor()),

--- a/vae/main.py
+++ b/vae/main.py
@@ -25,8 +25,6 @@ use_accel = not args.no_accel and torch.accelerator.is_available()
 
 torch.manual_seed(args.seed)
 
-if args.no_accel and torch.accelerator.is_available():
-    print("WARNING: accelerator is available, remove --no-accel to enable accelerator")
 
 if use_accel:
     device = torch.accelerator.current_accelerator()


### PR DESCRIPTION
This pull request updates the VAE and Siamese examples to restore the default configuration for CI using the Accelerator API. The previous changes inadvertently altered the default settings, which are necessary for consistent CI performance and testing.

Changes:

- Reverted default changes in the VAE example to align with CI requirements.
- Reverted default changes in the Siamese example to align with CI requirements.
- Ensured compatibility with the Accelerator API for both examples.

CC: @msaroufim, @malfet, @dvrogozh