### PR TITLE
Use torch.accelerator in DCGAN example

### DIFF
--- a/dcgan/README.md
+++ b/dcgan/README.md
@@ -20,31 +20,35 @@ python download.py -c bedroom
 ## Usage
 
 ```
-usage: main.py [-h] --dataset DATASET --dataroot DATAROOT [--workers WORKERS]
-               [--batchSize BATCHSIZE] [--imageSize IMAGESIZE] [--nz NZ]
-               [--ngf NGF] [--ndf NDF] [--niter NITER] [--lr LR]
-               [--beta1 BETA1] [--cuda] [--ngpu NGPU] [--netG NETG]
-               [--netD NETD] [--mps]
+usage: main.py [-h] --dataset DATASET [--dataroot DATAROOT]
+               [--workers WORKERS] [--batchSize BATCHSIZE]
+               [--imageSize IMAGESIZE] [--nz NZ] [--ngf NGF] [--ndf NDF]
+               [--niter NITER] [--lr LR] [--beta1 BETA1] [--dry-run]
+               [--ngpu NGPU] [--netG NETG] [--netD NETD] [--outf OUTF]
+               [--manualSeed MANUALSEED] [--classes CLASSES] [--accel]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --dataset DATASET     cifar10 | lsun | mnist |imagenet | folder | lfw | fake
   --dataroot DATAROOT   path to dataset
   --workers WORKERS     number of data loading workers
-  --batchSize BATCHSIZE input batch size
-  --imageSize IMAGESIZE the height / width of the input image to network
+  --batchSize BATCHSIZE
+                        input batch size
+  --imageSize IMAGESIZE
+                        the height / width of the input image to network
   --nz NZ               size of the latent z vector
-  --ngf NGF             number of filters in the generator
-  --ndf NDF             number of filters in the discriminator
+  --ngf NGF             number of generator filters
+  --ndf NDF             number of discriminator filters
   --niter NITER         number of epochs to train for
   --lr LR               learning rate, default=0.0002
   --beta1 BETA1         beta1 for adam. default=0.5
-  --cuda                enables cuda
-  --mps                 enables macOS GPU
+  --dry-run             check a single training cycle works
   --ngpu NGPU           number of GPUs to use
   --netG NETG           path to netG (to continue training)
   --netD NETD           path to netD (to continue training)
   --outf OUTF           folder to output images and model checkpoints
-  --manualSeed SEED     manual seed
+  --manualSeed MANUALSEED
+                        manual seed
   --classes CLASSES     comma separated list of classes for the lsun data set
+  --accel               enables accelerator
 ```

--- a/dcgan/main.py
+++ b/dcgan/main.py
@@ -20,12 +20,11 @@ parser.add_argument('--workers', type=int, help='number of data loading workers'
 parser.add_argument('--batchSize', type=int, default=64, help='input batch size')
 parser.add_argument('--imageSize', type=int, default=64, help='the height / width of the input image to network')
 parser.add_argument('--nz', type=int, default=100, help='size of the latent z vector')
-parser.add_argument('--ngf', type=int, default=64)
-parser.add_argument('--ndf', type=int, default=64)
+parser.add_argument('--ngf', type=int, default=64, help='number of generator filters')
+parser.add_argument('--ndf', type=int, default=64, help='number of discriminator filters')
 parser.add_argument('--niter', type=int, default=25, help='number of epochs to train for')
 parser.add_argument('--lr', type=float, default=0.0002, help='learning rate, default=0.0002')
 parser.add_argument('--beta1', type=float, default=0.5, help='beta1 for adam. default=0.5')
-parser.add_argument('--cuda', action='store_true', default=False, help='enables cuda')
 parser.add_argument('--dry-run', action='store_true', help='check a single training cycle works')
 parser.add_argument('--ngpu', type=int, default=1, help='number of GPUs to use')
 parser.add_argument('--netG', default='', help="path to netG (to continue training)")
@@ -33,7 +32,7 @@ parser.add_argument('--netD', default='', help="path to netD (to continue traini
 parser.add_argument('--outf', default='.', help='folder to output images and model checkpoints')
 parser.add_argument('--manualSeed', type=int, help='manual seed')
 parser.add_argument('--classes', default='bedroom', help='comma separated list of classes for the lsun data set')
-parser.add_argument('--mps', action='store_true', default=False, help='enables macOS GPU training')
+parser.add_argument('--accel', action='store_true', default=False, help='enables accelerator')
 
 opt = parser.parse_args()
 print(opt)
@@ -51,12 +50,13 @@ torch.manual_seed(opt.manualSeed)
 
 cudnn.benchmark = True
 
-if torch.cuda.is_available() and not opt.cuda:
-    print("WARNING: You have a CUDA device, so you should probably run with --cuda")
+if opt.accel and torch.accelerator.is_available():
+    device = torch.accelerator.current_accelerator()
+else:
+    device = torch.device("cpu")
 
-if torch.backends.mps.is_available() and not opt.mps:
-    print("WARNING: You have mps device, to enable macOS GPU run with --mps")
-  
+print(f"Using device: {device}")
+
 if opt.dataroot is None and str(opt.dataset).lower() != 'fake':
     raise ValueError("`dataroot` parameter is required for dataset \"%s\"" % opt.dataset)
 
@@ -106,13 +106,6 @@ elif opt.dataset == 'fake':
 assert dataset
 dataloader = torch.utils.data.DataLoader(dataset, batch_size=opt.batchSize,
                                          shuffle=True, num_workers=int(opt.workers))
-use_mps = opt.mps and torch.backends.mps.is_available()
-if opt.cuda:
-    device = torch.device("cuda:0")
-elif use_mps:
-    device = torch.device("mps")
-else:
-    device = torch.device("cpu")
 
 ngpu = int(opt.ngpu)
 nz = int(opt.nz)
@@ -158,7 +151,8 @@ class Generator(nn.Module):
         )
 
     def forward(self, input):
-        if input.is_cuda and self.ngpu > 1:
+        
+        if (input.is_cuda or input.is_xpu) and self.ngpu > 1:
             output = nn.parallel.data_parallel(self.main, input, range(self.ngpu))
         else:
             output = self.main(input)
@@ -198,7 +192,7 @@ class Discriminator(nn.Module):
         )
 
     def forward(self, input):
-        if input.is_cuda and self.ngpu > 1:
+        if (input.is_cuda or input.is_xpu) and self.ngpu > 1:
             output = nn.parallel.data_parallel(self.main, input, range(self.ngpu))
         else:
             output = self.main(input)

--- a/dcgan/requirements.txt
+++ b/dcgan/requirements.txt
@@ -1,3 +1,3 @@
 torch
-torchvision==0.20.0
+torchvision
 lmdb

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -58,7 +58,7 @@ case $USE_CUDA in
 esac
 
 function dcgan() {
-  uv run main.py --dataset fake $CUDA_FLAG --mps --dry-run || error "dcgan failed"
+  uv run main.py --dataset fake $ACCEL_FLAG --dry-run || error "dcgan failed"
 }
 
 function fast_neural_style() {


### PR DESCRIPTION
Refactor DCGAN examples to utilize torch.accelerator API torch.accelerator API allows to abstract some of the accelerator specifics in the user scripts. By leveraging this API, the code becomes more adaptable to various hardware accelerators.
- Updated dcgan/main.py with accelerator flag 
- Updated README to match dcgan/main.py
- Updated requirements, removed pinned torchvision version
- Updated run_python_examples.sh to match new accelerator flag

CC: @msaroufim, @malfet, @dvrogozh