### PR TITLE
Fix torch>= 2.6 generate.py compatibility in Word_language_example

### DIFF
--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -154,10 +154,11 @@ function vision_transformer() {
 
 function word_language_model() {
   uv run main.py --epochs 1 --dry-run $CUDA_FLAG --mps || error "word_language_model failed"
+  uv run generate.py $CUDA_FLAG --mps || error "word_language_model generate failed"
   for model in "RNN_TANH" "RNN_RELU" "LSTM" "GRU" "Transformer"; do
     uv run main.py --model $model --epochs 1 --dry-run $CUDA_FLAG --mps || error "word_language_model failed"
+    uv run generate.py $CUDA_FLAG --mps || error "word_language_model generate failed"
   done
-  uv run generate.py $CUDA_FLAG --mps || error "word_language_model generate failed"
 }
 
 function gcn() {

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -157,6 +157,7 @@ function word_language_model() {
   for model in "RNN_TANH" "RNN_RELU" "LSTM" "GRU" "Transformer"; do
     uv run main.py --model $model --epochs 1 --dry-run $CUDA_FLAG --mps || error "word_language_model failed"
   done
+  uv run generate.py $CUDA_FLAG --mps || error "word_language_model generate failed"
 }
 
 function gcn() {

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -8,6 +8,7 @@ import argparse
 import torch
 
 import data
+from model import PositionalEncoding, RNNModel, TransformerModel
 
 parser = argparse.ArgumentParser(description='PyTorch Wikitext-2 Language Model')
 # Model parameters.
@@ -52,7 +53,29 @@ if args.temperature < 1e-3:
     parser.error("--temperature has to be greater or equal 1e-3.")
 
 with open(args.checkpoint, 'rb') as f:
-    model = torch.load(f, map_location=device)
+    safe_globals = [
+        PositionalEncoding,
+        TransformerModel,
+        torch.nn.functional.relu,
+        torch.nn.modules.activation.MultiheadAttention,
+        torch.nn.modules.container.ModuleList,
+        torch.nn.modules.dropout.Dropout,
+        torch.nn.modules.linear.Linear,
+        torch.nn.modules.linear.NonDynamicallyQuantizableLinear,
+        torch.nn.modules.normalization.LayerNorm,
+        torch.nn.modules.sparse.Embedding,
+        torch.nn.modules.transformer.TransformerEncoder,
+        torch.nn.modules.transformer.TransformerEncoderLayer,
+        RNNModel,
+        torch.nn.modules.dropout.Dropout,
+        torch.nn.modules.linear.Linear,
+        torch.nn.modules.rnn.GRU,
+        torch.nn.modules.rnn.LSTM,
+        torch.nn.modules.rnn.RNN,
+        torch.nn.modules.sparse.Embedding,
+    ]
+    with torch.serialization.safe_globals(safe_globals):
+        model = torch.load(f, map_location=device)
 model.eval()
 
 corpus = data.Corpus(args.data)

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -55,6 +55,7 @@ if args.temperature < 1e-3:
 with open(args.checkpoint, 'rb') as f:
     safe_globals = [
         PositionalEncoding,
+        RNNModel,
         TransformerModel,
         torch.nn.functional.relu,
         torch.nn.modules.activation.MultiheadAttention,
@@ -64,15 +65,11 @@ with open(args.checkpoint, 'rb') as f:
         torch.nn.modules.linear.NonDynamicallyQuantizableLinear,
         torch.nn.modules.normalization.LayerNorm,
         torch.nn.modules.sparse.Embedding,
-        torch.nn.modules.transformer.TransformerEncoder,
-        torch.nn.modules.transformer.TransformerEncoderLayer,
-        RNNModel,
-        torch.nn.modules.dropout.Dropout,
-        torch.nn.modules.linear.Linear,
         torch.nn.modules.rnn.GRU,
         torch.nn.modules.rnn.LSTM,
         torch.nn.modules.rnn.RNN,
-        torch.nn.modules.sparse.Embedding,
+        torch.nn.modules.transformer.TransformerEncoder,
+        torch.nn.modules.transformer.TransformerEncoderLayer,
     ]
     with torch.serialization.safe_globals(safe_globals):
         model = torch.load(f, map_location=device)


### PR DESCRIPTION
Update example's generate.py usage of torch.load() with required safe globals.

CC: @msaroufim, @dvrogozh, @jafraustro