### PR TITLE
Update main.py tutorial, set persistent_workers, make GPU execution faster

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -107,6 +107,7 @@ def main():
     test_kwargs = {'batch_size': args.test_batch_size}
     if use_accel:
         accel_kwargs = {'num_workers': 1,
+                        'persistent_workers': True,
                        'pin_memory': True,
                        'shuffle': True}
         train_kwargs.update(accel_kwargs)


### PR DESCRIPTION
Since we are setting num_workers to 1, we should either make this worker persistent or not set the num_workers. On my machine, running this script as is takes 2.21 mins, setting the workers to persistent or removing num_workers (setting to its default of 0) makes it a good deal faster at 1.44 and  1.66 mins respectively. 

I would opt for adding the persistent_workers setting as it is a little faster and makes it trivial for even a beginner to speed it up further by increasing the num_workers (setting to 10 reduced my run time to 0.53 mins