### PR TITLE
silence destroy_proces_group() warning

### DIFF
--- a/distributed/tensor_parallelism/fsdp_tp_example.py
+++ b/distributed/tensor_parallelism/fsdp_tp_example.py
@@ -173,3 +173,6 @@ for i in range(num_iterations):
     rank_log(_rank, logger, f"2D iter {i} complete")
 
 rank_log(_rank, logger, "2D training successfully completed!")
+
+if dist.is_initialized():
+    dist.destroy_process_group()

--- a/distributed/tensor_parallelism/sequence_parallel_example.py
+++ b/distributed/tensor_parallelism/sequence_parallel_example.py
@@ -22,6 +22,7 @@ import sys
 import torch
 import torch.nn as nn
 
+import torch.distributed as dist
 from torch.distributed._tensor import Shard
 
 from torch.distributed.tensor.parallel import (
@@ -107,3 +108,6 @@ for i in range(num_iters):
     rank_log(_rank, logger, f"Sequence Parallel iter {i} completed")
 
 rank_log(_rank, logger, "Sequence Parallel training completed!")
+
+if dist.is_initialized():
+    dist.destroy_process_group()

--- a/distributed/tensor_parallelism/tensor_parallel_example.py
+++ b/distributed/tensor_parallelism/tensor_parallel_example.py
@@ -122,3 +122,6 @@ for i in range(num_iters):
     rank_log(_rank, logger, f"Tensor Parallel iter {i} completed")
 
 rank_log(_rank, logger, "Tensor Parallel training completed!")
+
+if dist.is_initialized():
+    dist.destroy_process_group()


### PR DESCRIPTION
All these examples have warnings of the below sort

```
[rank0]:[W825 13:09:39.967659278 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
(create) ➜  tensor_parallelism git:(main) ✗ CUDA_VISIBLE_DEVICES=4,5,6,7 torchrun --nnodes=1 --nproc_per_node=4 tensor_parallel_example.py
```

I don't think they're "dangerous" since people seem to ignore them just fine so this is just to be nice