### PR TITLE
Use of torch.inference_mode() instead of torch.no_grad() for inference

### DIFF
--- a/mnist/main.py
+++ b/mnist/main.py
@@ -54,7 +54,7 @@ def test(model, device, test_loader):
     model.eval()
     test_loss = 0
     correct = 0
-    with torch.no_grad():
+    with torch.inference_mode():
         for data, target in test_loader:
             data, target = data.to(device), target.to(device)
             output = model(data)


### PR DESCRIPTION
Replaced the `torch.no_grad()` context manager with the `torch.inference_mode()` context manager in the test function.

Why? `torch.inference_mode()` is more efficient as it reduces memory usage, inference speed and it disabled autograd completely. 

Tested with `run_python_examples.sh` locally, all tests passed succesfully.