### PR TITLE
Provide an additional --xla flag to be able to run this test on TPU if available

### DIFF
--- a/mnist/README.md
+++ b/mnist/README.md
@@ -1,7 +1,57 @@
-# Basic MNIST Example
+# MNIST Example
+
+Trains a ConvNet on the MNIST dataset using PyTorch.
+
+## Usage
+
+### Standard (CUDA / MPS / XPU)
 
 ```bash
 pip install -r requirements.txt
 python main.py
-# CUDA_VISIBLE_DEVICES=2 python main.py  # to specify GPU id to ex. 2
+# or to run on CPU only:
+python main.py --no-accel
+```
+
+### TPU (via PyTorch/XLA)
+
+To train on a Google Cloud TPU VM:
+
+```bash
+# Install PyTorch/XLA (adjust version as needed)
+pip install torch torchvision
+pip install 'torch_xla[tpu]'
+
+# Run with the --xla flag
+python main.py --xla
+```
+
+**Notes on TPU training:**
+- The `--xla` flag selects the XLA device (TPU). It takes precedence over `torch.accelerator`.
+- `drop_last=True` is used for the training DataLoader to ensure fixed batch shapes, which avoids recompilation on TPU.
+- Model checkpoints saved with `--save-model` are moved to CPU before saving for cross-device portability.
+- For multi-device TPU training (e.g. all 4 chips on a v4-8), see the [PyTorch/XLA multiprocessing guide](https://docs.pytorch.org/xla/master/learn/pytorch-on-xla-devices.html).
+
+### Options
+
+```
+usage: main.py [-h] [--batch-size N] [--test-batch-size N] [--epochs N]
+               [--lr LR] [--gamma M] [--no-accel] [--xla] [--dry-run]
+               [--seed S] [--log-interval N] [--save-model]
+
+PyTorch MNIST Example
+
+options:
+  -h, --help           show this help message and exit
+  --batch-size N       input batch size for training (default: 64)
+  --test-batch-size N  input batch size for testing (default: 1000)
+  --epochs N           number of epochs to train (default: 14)
+  --lr LR              learning rate (default: 1.0)
+  --gamma M            Learning rate step gamma (default: 0.7)
+  --no-accel           disables accelerator
+  --xla                enables XLA device (e.g. TPU). Requires torch_xla.
+  --dry-run            quickly check a single pass
+  --seed S             random seed (default: 1)
+  --log-interval N     how many batches to wait before logging training status
+  --save-model         For Saving the current Model
 ```

--- a/mnist/README.md
+++ b/mnist/README.md
@@ -15,22 +15,13 @@ python main.py --no-accel
 
 ### TPU (via PyTorch/XLA)
 
-To train on a Google Cloud TPU VM:
-
 ```bash
-# Install PyTorch/XLA (adjust version as needed)
 pip install torch torchvision
 pip install 'torch_xla[tpu]'
-
-# Run with the --xla flag
 python main.py --xla
 ```
 
-**Notes on TPU training:**
-- The `--xla` flag selects the XLA device (TPU). It takes precedence over `torch.accelerator`.
-- `drop_last=True` is used for the training DataLoader to ensure fixed batch shapes, which avoids recompilation on TPU.
-- Model checkpoints saved with `--save-model` are moved to CPU before saving for cross-device portability.
-- For multi-device TPU training (e.g. all 4 chips on a v4-8), see the [PyTorch/XLA multiprocessing guide](https://docs.pytorch.org/xla/master/learn/pytorch-on-xla-devices.html).
+For multi-device TPU training, see the [PyTorch/XLA multiprocessing guide](https://docs.pytorch.org/xla/master/learn/pytorch-on-xla-devices.html).
 
 ### Options
 

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -52,6 +52,7 @@ def train(args, model, device, train_loader, optimizer, epoch):
         loss.backward()
         if args.xla:
             xm.optimizer_step(optimizer)
+            xm.mark_step()
         else:
             optimizer.step()
         if batch_idx % args.log_interval == 0:

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -7,6 +7,16 @@ from torchvision import datasets, transforms
 from torch.optim.lr_scheduler import StepLR
 
 
+# Optional: XLA/TPU support
+_XLA_AVAILABLE = False
+try:
+    import torch_xla
+    import torch_xla.core.xla_model as xm
+    _XLA_AVAILABLE = True
+except ImportError:
+    pass
+
+
 class Net(nn.Module):
     def __init__(self):
         super(Net, self).__init__()
@@ -41,8 +51,15 @@ def train(args, model, device, train_loader, optimizer, epoch):
         output = model(data)
         loss = F.nll_loss(output, target)
         loss.backward()
-        optimizer.step()
+        # On XLA devices, use xm.optimizer_step to sync gradients properly.
+        # On other devices, use the standard optimizer.step().
+        if args.xla:
+            xm.optimizer_step(optimizer)
+        else:
+            optimizer.step()
         if batch_idx % args.log_interval == 0:
+            # On XLA, .item() triggers a device-to-host sync. We accept
+            # this cost at logging boundaries for readability.
             print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
                 epoch, batch_idx * len(data), len(train_loader.dataset),
                 100. * batch_idx / len(train_loader), loss.item()))
@@ -84,36 +101,58 @@ def main():
                         help='Learning rate step gamma (default: 0.7)')
     parser.add_argument('--no-accel', action='store_true',
                         help='disables accelerator')
+    parser.add_argument('--xla', action='store_true', default=False,
+                        help='enables XLA device (e.g. TPU). Requires torch_xla.')
     parser.add_argument('--dry-run', action='store_true',
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
-    parser.add_argument('--save-model', action='store_true', 
+    parser.add_argument('--save-model', action='store_true',
                         help='For Saving the current Model')
     args = parser.parse_args()
 
-    use_accel = not args.no_accel and torch.accelerator.is_available()
+    # Device selection: --xla takes precedence, then torch.accelerator, then CPU.
+    if args.xla:
+        if not _XLA_AVAILABLE:
+            raise RuntimeError(
+                "--xla flag requires torch_xla to be installed. "
+                "Install with: pip install torch_xla[tpu]"
+            )
+        device = xm.xla_device()
+        print(f"Using XLA device: {device}")
+    else:
+        use_accel = not args.no_accel and torch.accelerator.is_available()
+        if use_accel:
+            device = torch.accelerator.current_accelerator()
+        else:
+            device = torch.device("cpu")
 
     torch.manual_seed(args.seed)
 
-    if use_accel:
-        device = torch.accelerator.current_accelerator()
-    else:
-        device = torch.device("cpu")
-
     train_kwargs = {'batch_size': args.batch_size}
     test_kwargs = {'batch_size': args.test_batch_size}
-    if use_accel:
+
+    if args.xla:
+        # On XLA/TPU: pin_memory is not needed (no host-device DMA path),
+        # and persistent_workers helps avoid re-forking.
+        xla_kwargs = {'num_workers': 4,
+                      'persistent_workers': True,
+                      'shuffle': True,
+                      'drop_last': True}
+        train_kwargs.update(xla_kwargs)
+        # For test, don't drop_last so we evaluate every sample.
+        test_kwargs.update({'num_workers': 4, 'persistent_workers': True})
+    elif not args.no_accel and torch.accelerator.is_available():
         accel_kwargs = {'num_workers': 1,
                         'persistent_workers': True,
-                       'pin_memory': True,
-                       'shuffle': True}
+                        'pin_memory': True,
+                        'shuffle': True}
         train_kwargs.update(accel_kwargs)
         test_kwargs.update(accel_kwargs)
 
-    transform=transforms.Compose([
+    transform = transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize((0.1307,), (0.3081,))
         ])
@@ -121,7 +160,7 @@ def main():
                        transform=transform)
     dataset2 = datasets.MNIST('../data', train=False,
                        transform=transform)
-    train_loader = torch.utils.data.DataLoader(dataset1,**train_kwargs)
+    train_loader = torch.utils.data.DataLoader(dataset1, **train_kwargs)
     test_loader = torch.utils.data.DataLoader(dataset2, **test_kwargs)
 
     model = Net().to(device)
@@ -132,9 +171,19 @@ def main():
         train(args, model, device, train_loader, optimizer, epoch)
         test(model, device, test_loader)
         scheduler.step()
+        # On XLA, explicitly sync at epoch boundaries to ensure all
+        # device computations have completed.
+        if args.xla:
+            xm.mark_step()
 
     if args.save_model:
-        torch.save(model.state_dict(), "mnist_cnn.pt")
+        # On XLA devices, move the model to CPU before saving for portability.
+        if args.xla:
+            model_to_save = model.cpu()
+            torch.save(model_to_save.state_dict(), "mnist_cnn.pt")
+            model.to(device)  # move back if needed
+        else:
+            torch.save(model.state_dict(), "mnist_cnn.pt")
 
 
 if __name__ == '__main__':

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -10,7 +10,6 @@ from torch.optim.lr_scheduler import StepLR
 _XLA_AVAILABLE = False
 try:
     import torch_xla
-    import torch_xla.core.xla_model as xm
     _XLA_AVAILABLE = True
 except ImportError:
     pass
@@ -50,11 +49,9 @@ def train(args, model, device, train_loader, optimizer, epoch):
         output = model(data)
         loss = F.nll_loss(output, target)
         loss.backward()
+        optimizer.step()
         if args.xla:
-            xm.optimizer_step(optimizer)
-            xm.mark_step()
-        else:
-            optimizer.step()
+            torch_xla.sync()
         if batch_idx % args.log_interval == 0:
             print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
                 epoch, batch_idx * len(data), len(train_loader.dataset),
@@ -115,7 +112,7 @@ def main():
                 "--xla flag requires torch_xla to be installed. "
                 "Install with: pip install torch_xla[tpu]"
             )
-        device = xm.xla_device()
+        device = torch_xla.device()
     else:
         use_accel = not args.no_accel and torch.accelerator.is_available()
         device = torch.accelerator.current_accelerator() if use_accel else torch.device("cpu")
@@ -157,8 +154,6 @@ def main():
         train(args, model, device, train_loader, optimizer, epoch)
         test(model, device, test_loader)
         scheduler.step()
-        if args.xla:
-            xm.mark_step()
 
     if args.save_model:
         if args.xla:

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -7,7 +7,6 @@ from torchvision import datasets, transforms
 from torch.optim.lr_scheduler import StepLR
 
 
-# Optional: XLA/TPU support
 _XLA_AVAILABLE = False
 try:
     import torch_xla
@@ -51,15 +50,11 @@ def train(args, model, device, train_loader, optimizer, epoch):
         output = model(data)
         loss = F.nll_loss(output, target)
         loss.backward()
-        # On XLA devices, use xm.optimizer_step to sync gradients properly.
-        # On other devices, use the standard optimizer.step().
         if args.xla:
             xm.optimizer_step(optimizer)
         else:
             optimizer.step()
         if batch_idx % args.log_interval == 0:
-            # On XLA, .item() triggers a device-to-host sync. We accept
-            # this cost at logging boundaries for readability.
             print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
                 epoch, batch_idx * len(data), len(train_loader.dataset),
                 100. * batch_idx / len(train_loader), loss.item()))
@@ -113,7 +108,6 @@ def main():
                         help='For Saving the current Model')
     args = parser.parse_args()
 
-    # Device selection: --xla takes precedence, then torch.accelerator, then CPU.
     if args.xla:
         if not _XLA_AVAILABLE:
             raise RuntimeError(
@@ -121,13 +115,9 @@ def main():
                 "Install with: pip install torch_xla[tpu]"
             )
         device = xm.xla_device()
-        print(f"Using XLA device: {device}")
     else:
         use_accel = not args.no_accel and torch.accelerator.is_available()
-        if use_accel:
-            device = torch.accelerator.current_accelerator()
-        else:
-            device = torch.device("cpu")
+        device = torch.accelerator.current_accelerator() if use_accel else torch.device("cpu")
 
     torch.manual_seed(args.seed)
 
@@ -135,20 +125,12 @@ def main():
     test_kwargs = {'batch_size': args.test_batch_size}
 
     if args.xla:
-        # On XLA/TPU: pin_memory is not needed (no host-device DMA path),
-        # and persistent_workers helps avoid re-forking.
-        xla_kwargs = {'num_workers': 4,
-                      'persistent_workers': True,
-                      'shuffle': True,
-                      'drop_last': True}
-        train_kwargs.update(xla_kwargs)
-        # For test, don't drop_last so we evaluate every sample.
+        train_kwargs.update({'num_workers': 4, 'persistent_workers': True,
+                             'shuffle': True, 'drop_last': True})
         test_kwargs.update({'num_workers': 4, 'persistent_workers': True})
     elif not args.no_accel and torch.accelerator.is_available():
-        accel_kwargs = {'num_workers': 1,
-                        'persistent_workers': True,
-                        'pin_memory': True,
-                        'shuffle': True}
+        accel_kwargs = {'num_workers': 1, 'persistent_workers': True,
+                        'pin_memory': True, 'shuffle': True}
         train_kwargs.update(accel_kwargs)
         test_kwargs.update(accel_kwargs)
 
@@ -171,17 +153,12 @@ def main():
         train(args, model, device, train_loader, optimizer, epoch)
         test(model, device, test_loader)
         scheduler.step()
-        # On XLA, explicitly sync at epoch boundaries to ensure all
-        # device computations have completed.
         if args.xla:
             xm.mark_step()
 
     if args.save_model:
-        # On XLA devices, move the model to CPU before saving for portability.
         if args.xla:
-            model_to_save = model.cpu()
-            torch.save(model_to_save.state_dict(), "mnist_cnn.pt")
-            model.to(device)  # move back if needed
+            torch.save(model.cpu().state_dict(), "mnist_cnn.pt")
         else:
             torch.save(model.state_dict(), "mnist_cnn.pt")
 

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -147,7 +147,10 @@ def main():
     test_loader = torch.utils.data.DataLoader(dataset2, **test_kwargs)
 
     model = Net().to(device)
-    optimizer = optim.Adadelta(model.parameters(), lr=args.lr)
+    if args.xla:
+        optimizer = optim.Adam(model.parameters(), lr=1e-3)
+    else:
+        optimizer = optim.Adadelta(model.parameters(), lr=args.lr)
 
     scheduler = StepLR(optimizer, step_size=1, gamma=args.gamma)
     for epoch in range(1, args.epochs + 1):

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This script runs through the code in each of the python examples.
-# The purpose is just as an integration test, not to actually train models in any meaningful way.
+# The purpose is just as an integration test, not to actually train models in any meaningful way.
 # For that reason, most of these set epochs = 1 and --dry-run.
 #
 # Optionally specify a comma separated list of examples to run. Can be run as:
@@ -91,7 +91,7 @@ function language_translation() {
 }
 
 function mnist() {
-  uv run main.py --epochs 1 --dry-run || error "mnist example failed"
+  uv run main.py --epochs 1 --dry-run $ACCEL_FLAG || error "mnist example failed"
 }
 function mnist_forward_forward() {
   uv run main.py --epochs 1 --no_accel || error "mnist forward forward failed"


### PR DESCRIPTION
I'm a Kubernetes/Kubernetes contributor, and this is my first PR to Pytorch.

1. Trying to provide support for running this test on TPU
2. if it's a pattern that works, maybe I can generalize for other tests?
3. If I should be doing it in a different way I'm open to feedback and learning
4. I ran the test on a TPU machine and it worked, even at epoch 1:

`fbongiovanni@t1v-n-02c64e41-w-0:~/examples/mnist$ python main.py --xla --log-interval 100
WARNING:root:libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.
Train Epoch: 1 [0/60000 (0%)]	Loss: 2.300604
Train Epoch: 1 [6400/60000 (11%)]	Loss: 0.244346
Train Epoch: 1 [12800/60000 (21%)]	Loss: 0.055622
Train Epoch: 1 [19200/60000 (32%)]	Loss: 0.200639
Train Epoch: 1 [25600/60000 (43%)]	Loss: 0.093245
Train Epoch: 1 [32000/60000 (53%)]	Loss: 0.159420
Train Epoch: 1 [38400/60000 (64%)]	Loss: 0.148803
Train Epoch: 1 [44800/60000 (75%)]	Loss: 0.116827
Train Epoch: 1 [51200/60000 (85%)]	Loss: 0.054931
Train Epoch: 1 [57600/60000 (96%)]	Loss: 0.068974

Test set: Average loss: 0.0475, Accuracy: 9852/10000 (99%)`

Thanks!
Federico