### PR TITLE
vae example: provide an additional --xla flag to be able to run this test on TPU if available

### DIFF
--- a/vae/README.md
+++ b/vae/README.md
@@ -22,13 +22,21 @@ To force execution on the CPU, use `--no-accel` command line argument:
 python main.py --no-accel
 ```
 
+To run on a TPU via XLA, install `torch_xla` and use the `--xla` flag:
+
+```bash
+pip install torch_xla[tpu]
+python main.py --xla
+```
+
 The main.py script accepts the following optional arguments:
 
 ```bash
 --batch-size            input batch size for training (default: 128)
 --epochs                number of epochs to train (default: 10)
 --no-accel              disables accelerator
+--xla                   enables XLA device (e.g. TPU). Requires torch_xla.
 --seed                  random seed (default: 1)
---log-interval	        how many batches to wait before logging training status
+--log-interval          how many batches to wait before logging training status
 ```
 

--- a/vae/main.py
+++ b/vae/main.py
@@ -8,39 +8,62 @@ from torchvision import datasets, transforms
 from torchvision.utils import save_image
 
 
+_XLA_AVAILABLE = False
+try:
+    import torch_xla
+    _XLA_AVAILABLE = True
+except ImportError:
+    pass
+
+
 parser = argparse.ArgumentParser(description='VAE MNIST Example')
 parser.add_argument('--batch-size', type=int, default=128, metavar='N',
                     help='input batch size for training (default: 128)')
 parser.add_argument('--epochs', type=int, default=10, metavar='N',
                     help='number of epochs to train (default: 10)')
-parser.add_argument('--no-accel', action='store_true', 
+parser.add_argument('--no-accel', action='store_true',
                     help='disables accelerator')
+parser.add_argument('--xla', action='store_true', default=False,
+                    help='enables XLA device (e.g. TPU). Requires torch_xla.')
 parser.add_argument('--seed', type=int, default=1, metavar='S',
                     help='random seed (default: 1)')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                     help='how many batches to wait before logging training status')
 args = parser.parse_args()
 
-use_accel = not args.no_accel and torch.accelerator.is_available()
+if args.xla:
+    if not _XLA_AVAILABLE:
+        raise RuntimeError(
+            "--xla flag requires torch_xla to be installed. "
+            "Install with: pip install torch_xla[tpu]"
+        )
+    device = torch_xla.device()
+else:
+    use_accel = not args.no_accel and torch.accelerator.is_available()
+    device = torch.accelerator.current_accelerator() if use_accel else torch.device("cpu")
 
 torch.manual_seed(args.seed)
 
-
-if use_accel:
-    device = torch.accelerator.current_accelerator()
-else:
-    device = torch.device("cpu")
-
 print(f"Using device: {device}")
 
-kwargs = {'num_workers': 1, 'pin_memory': True} if use_accel else {}
+train_kwargs = {'batch_size': args.batch_size}
+test_kwargs = {'batch_size': args.batch_size}
+
+if args.xla:
+    train_kwargs.update({'num_workers': 4, 'persistent_workers': True,
+                         'shuffle': True, 'drop_last': True})
+    test_kwargs.update({'num_workers': 4, 'persistent_workers': True})
+elif not args.no_accel and torch.accelerator.is_available():
+    train_kwargs.update({'num_workers': 1, 'pin_memory': True, 'shuffle': True})
+    test_kwargs.update({'num_workers': 1, 'pin_memory': True})
+
 train_loader = torch.utils.data.DataLoader(
     datasets.MNIST('../data', train=True, download=True,
                    transform=transforms.ToTensor()),
-    batch_size=args.batch_size, shuffle=True, **kwargs)
+    **train_kwargs)
 test_loader = torch.utils.data.DataLoader(
     datasets.MNIST('../data', train=False, transform=transforms.ToTensor()),
-    batch_size=args.batch_size, shuffle=False, **kwargs)
+    **test_kwargs)
 
 
 class VAE(nn.Module):
@@ -100,6 +123,8 @@ def train(epoch):
         loss.backward()
         train_loss += loss.item()
         optimizer.step()
+        if args.xla:
+            torch_xla.sync()
         if batch_idx % args.log_interval == 0:
             print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
                 epoch, batch_idx * len(data), len(train_loader.dataset),

--- a/vae/main.py
+++ b/vae/main.py
@@ -114,14 +114,14 @@ def loss_function(recon_x, x, mu, logvar):
 
 def train(epoch):
     model.train()
-    train_loss = 0
+    train_loss = torch.tensor(0.0, device=device)
     for batch_idx, (data, _) in enumerate(train_loader):
         data = data.to(device)
         optimizer.zero_grad()
         recon_batch, mu, logvar = model(data)
         loss = loss_function(recon_batch, data, mu, logvar)
         loss.backward()
-        train_loss += loss.item()
+        train_loss += loss.detach()
         optimizer.step()
         if args.xla:
             torch_xla.sync()
@@ -132,7 +132,7 @@ def train(epoch):
                 loss.item() / len(data)))
 
     print('====> Epoch: {} Average loss: {:.4f}'.format(
-          epoch, train_loss / len(train_loader.dataset)))
+          epoch, train_loss.item() / len(train_loader.dataset)))
 
 
 def test(epoch):


### PR DESCRIPTION
I'm a Kubernetes/Kubernetes contributor, and this is my second PR to Pytorch.

- Trying to provide support for running this test on TPU
- if it's a pattern that works, maybe I can generalize for other tests?
- If I should be doing it in a different way I'm open to feedback and learning
- I ran the test on a TPU machine and it worked well:

```
fbongiovanni@tpu-machine:~/examples/vae$ python main.py --xla
WARNING:root:libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.
Using device: xla:0

Train Epoch: 1 [0/60000 (0%)]	Loss: 550.090759
Train Epoch: 1 [1280/60000 (2%)]	Loss: 309.806580
Train Epoch: 1 [2560/60000 (4%)]	Loss: 239.241318
Train Epoch: 1 [3840/60000 (6%)]	Loss: 218.358322
Train Epoch: 1 [5120/60000 (9%)]	Loss: 214.537491
Train Epoch: 1 [6400/60000 (11%)]	Loss: 206.811737
Train Epoch: 1 [7680/60000 (13%)]	Loss: 202.388672
Train Epoch: 1 [8960/60000 (15%)]	Loss: 193.017868
Train Epoch: 1 [10240/60000 (17%)]	Loss: 193.463669
Train Epoch: 1 [11520/60000 (19%)]	Loss: 188.439194
Train Epoch: 1 [12800/60000 (21%)]	Loss: 176.893417
Train Epoch: 1 [14080/60000 (24%)]	Loss: 172.542694
Train Epoch: 1 [15360/60000 (26%)]	Loss: 180.381912
Train Epoch: 1 [16640/60000 (28%)]	Loss: 167.364578
Train Epoch: 1 [17920/60000 (30%)]	Loss: 167.048584
Train Epoch: 1 [19200/60000 (32%)]	Loss: 161.996231
Train Epoch: 1 [20480/60000 (34%)]	Loss: 162.211212
Train Epoch: 1 [21760/60000 (36%)]	Loss: 151.992920
Train Epoch: 1 [23040/60000 (38%)]	Loss: 156.605194
Train Epoch: 1 [24320/60000 (41%)]	Loss: 153.035873
Train Epoch: 1 [25600/60000 (43%)]	Loss: 154.042862
Train Epoch: 1 [26880/60000 (45%)]	Loss: 151.196518
Train Epoch: 1 [28160/60000 (47%)]	Loss: 152.156769
Train Epoch: 1 [29440/60000 (49%)]	Loss: 146.066681
Train Epoch: 1 [30720/60000 (51%)]	Loss: 140.780899
Train Epoch: 1 [32000/60000 (53%)]	Loss: 144.829285
Train Epoch: 1 [33280/60000 (56%)]	Loss: 144.829865
Train Epoch: 1 [34560/60000 (58%)]	Loss: 145.363281
Train Epoch: 1 [35840/60000 (60%)]	Loss: 137.880508
Train Epoch: 1 [37120/60000 (62%)]	Loss: 141.642624
Train Epoch: 1 [38400/60000 (64%)]	Loss: 140.646713
Train Epoch: 1 [39680/60000 (66%)]	Loss: 135.799362
Train Epoch: 1 [40960/60000 (68%)]	Loss: 141.848450
Train Epoch: 1 [42240/60000 (71%)]	Loss: 140.472748
Train Epoch: 1 [43520/60000 (73%)]	Loss: 141.802094
Train Epoch: 1 [44800/60000 (75%)]	Loss: 135.276871
Train Epoch: 1 [46080/60000 (77%)]	Loss: 139.750504
Train Epoch: 1 [47360/60000 (79%)]	Loss: 131.497086
Train Epoch: 1 [48640/60000 (81%)]	Loss: 132.883118
Train Epoch: 1 [49920/60000 (83%)]	Loss: 130.220840
Train Epoch: 1 [51200/60000 (85%)]	Loss: 130.095367
Train Epoch: 1 [52480/60000 (88%)]	Loss: 131.399826
Train Epoch: 1 [53760/60000 (90%)]	Loss: 132.221252
Train Epoch: 1 [55040/60000 (92%)]	Loss: 127.463051
Train Epoch: 1 [56320/60000 (94%)]	Loss: 138.206284
Train Epoch: 1 [57600/60000 (96%)]	Loss: 130.146957
Train Epoch: 1 [58880/60000 (98%)]	Loss: 131.179184
====> Epoch: 1 Average loss: 163.7409
====> Test set loss: 127.1205
Train Epoch: 2 [0/60000 (0%)]	Loss: 131.180252
Train Epoch: 2 [1280/60000 (2%)]	Loss: 125.358856
Train Epoch: 2 [2560/60000 (4%)]	Loss: 123.535408
Train Epoch: 2 [3840/60000 (6%)]	Loss: 127.308060
Train Epoch: 2 [5120/60000 (9%)]	Loss: 119.988739
Train Epoch: 2 [6400/60000 (11%)]	Loss: 124.291702
Train Epoch: 2 [7680/60000 (13%)]	Loss: 124.467171
Train Epoch: 2 [8960/60000 (15%)]	Loss: 122.967720
Train Epoch: 2 [10240/60000 (17%)]	Loss: 128.459503
Train Epoch: 2 [11520/60000 (19%)]	Loss: 124.438522
Train Epoch: 2 [12800/60000 (21%)]	Loss: 125.907570
Train Epoch: 2 [14080/60000 (24%)]	Loss: 124.379440
Train Epoch: 2 [15360/60000 (26%)]	Loss: 125.964249
Train Epoch: 2 [16640/60000 (28%)]	Loss: 119.389511
Train Epoch: 2 [17920/60000 (30%)]	Loss: 123.309349
Train Epoch: 2 [19200/60000 (32%)]	Loss: 122.814789
Train Epoch: 2 [20480/60000 (34%)]	Loss: 117.765747
Train Epoch: 2 [21760/60000 (36%)]	Loss: 123.348488
Train Epoch: 2 [23040/60000 (38%)]	Loss: 120.200714
Train Epoch: 2 [24320/60000 (41%)]	Loss: 120.038040
Train Epoch: 2 [25600/60000 (43%)]	Loss: 123.133614
Train Epoch: 2 [26880/60000 (45%)]	Loss: 125.300896
Train Epoch: 2 [28160/60000 (47%)]	Loss: 118.518661
Train Epoch: 2 [29440/60000 (49%)]	Loss: 117.834061
Train Epoch: 2 [30720/60000 (51%)]	Loss: 122.068253
Train Epoch: 2 [32000/60000 (53%)]	Loss: 119.512856
Train Epoch: 2 [33280/60000 (56%)]	Loss: 123.085289
Train Epoch: 2 [34560/60000 (58%)]	Loss: 116.173286
Train Epoch: 2 [35840/60000 (60%)]	Loss: 122.833855
Train Epoch: 2 [37120/60000 (62%)]	Loss: 120.587334
Train Epoch: 2 [38400/60000 (64%)]	Loss: 120.968216
Train Epoch: 2 [39680/60000 (66%)]	Loss: 119.995773
Train Epoch: 2 [40960/60000 (68%)]	Loss: 116.345703
Train Epoch: 2 [42240/60000 (71%)]	Loss: 116.263824
Train Epoch: 2 [43520/60000 (73%)]	Loss: 119.668457
Train Epoch: 2 [44800/60000 (75%)]	Loss: 115.796448
Train Epoch: 2 [46080/60000 (77%)]	Loss: 112.448547
Train Epoch: 2 [47360/60000 (79%)]	Loss: 118.339386
Train Epoch: 2 [48640/60000 (81%)]	Loss: 117.225815
Train Epoch: 2 [49920/60000 (83%)]	Loss: 121.087112
Train Epoch: 2 [51200/60000 (85%)]	Loss: 117.349396
Train Epoch: 2 [52480/60000 (88%)]	Loss: 116.837402
Train Epoch: 2 [53760/60000 (90%)]	Loss: 116.444855
Train Epoch: 2 [55040/60000 (92%)]	Loss: 119.458778
Train Epoch: 2 [56320/60000 (94%)]	Loss: 119.431198
Train Epoch: 2 [57600/60000 (96%)]	Loss: 115.516113
Train Epoch: 2 [58880/60000 (98%)]	Loss: 113.314346
====> Epoch: 2 Average loss: 121.3721
====> Test set loss: 115.7489
Train Epoch: 3 [0/60000 (0%)]	Loss: 113.083809
Train Epoch: 3 [1280/60000 (2%)]	Loss: 114.225235
Train Epoch: 3 [2560/60000 (4%)]	Loss: 114.588768
Train Epoch: 3 [3840/60000 (6%)]	Loss: 117.109222
Train Epoch: 3 [5120/60000 (9%)]	Loss: 116.307335
Train Epoch: 3 [6400/60000 (11%)]	Loss: 119.689697
Train Epoch: 3 [7680/60000 (13%)]	Loss: 122.398529
Train Epoch: 3 [8960/60000 (15%)]	Loss: 115.171303
Train Epoch: 3 [10240/60000 (17%)]	Loss: 116.118599
Train Epoch: 3 [11520/60000 (19%)]	Loss: 113.761742
Train Epoch: 3 [12800/60000 (21%)]	Loss: 119.232346
Train Epoch: 3 [14080/60000 (24%)]	Loss: 108.593575
Train Epoch: 3 [15360/60000 (26%)]	Loss: 112.319855
Train Epoch: 3 [16640/60000 (28%)]	Loss: 114.424042
Train Epoch: 3 [17920/60000 (30%)]	Loss: 112.421898
Train Epoch: 3 [19200/60000 (32%)]	Loss: 115.378372
Train Epoch: 3 [20480/60000 (34%)]	Loss: 120.073967
Train Epoch: 3 [21760/60000 (36%)]	Loss: 117.879272
Train Epoch: 3 [23040/60000 (38%)]	Loss: 117.741821
Train Epoch: 3 [24320/60000 (41%)]	Loss: 117.215248
Train Epoch: 3 [25600/60000 (43%)]	Loss: 114.374786
Train Epoch: 3 [26880/60000 (45%)]	Loss: 113.775208
Train Epoch: 3 [28160/60000 (47%)]	Loss: 113.669754
Train Epoch: 3 [29440/60000 (49%)]	Loss: 116.790070
Train Epoch: 3 [30720/60000 (51%)]	Loss: 111.285065
Train Epoch: 3 [32000/60000 (53%)]	Loss: 115.586227
Train Epoch: 3 [33280/60000 (56%)]	Loss: 117.696297
Train Epoch: 3 [34560/60000 (58%)]	Loss: 115.678162
Train Epoch: 3 [35840/60000 (60%)]	Loss: 116.541275
Train Epoch: 3 [37120/60000 (62%)]	Loss: 112.482430
Train Epoch: 3 [38400/60000 (64%)]	Loss: 116.348419
Train Epoch: 3 [39680/60000 (66%)]	Loss: 112.571915
Train Epoch: 3 [40960/60000 (68%)]	Loss: 114.040085
Train Epoch: 3 [42240/60000 (71%)]	Loss: 114.847809
Train Epoch: 3 [43520/60000 (73%)]	Loss: 114.545067
Train Epoch: 3 [44800/60000 (75%)]	Loss: 115.635590
Train Epoch: 3 [46080/60000 (77%)]	Loss: 108.720802
Train Epoch: 3 [47360/60000 (79%)]	Loss: 116.217422
Train Epoch: 3 [48640/60000 (81%)]	Loss: 119.697968
Train Epoch: 3 [49920/60000 (83%)]	Loss: 111.465927
Train Epoch: 3 [51200/60000 (85%)]	Loss: 113.056412
Train Epoch: 3 [52480/60000 (88%)]	Loss: 112.053574
Train Epoch: 3 [53760/60000 (90%)]	Loss: 112.903931
Train Epoch: 3 [55040/60000 (92%)]	Loss: 111.360062
Train Epoch: 3 [56320/60000 (94%)]	Loss: 112.961761
Train Epoch: 3 [57600/60000 (96%)]	Loss: 111.438461
Train Epoch: 3 [58880/60000 (98%)]	Loss: 115.951065
====> Epoch: 3 Average loss: 114.4051
====> Test set loss: 111.7873
Train Epoch: 4 [0/60000 (0%)]	Loss: 109.901566
Train Epoch: 4 [1280/60000 (2%)]	Loss: 111.223770
Train Epoch: 4 [2560/60000 (4%)]	Loss: 116.337006
Train Epoch: 4 [3840/60000 (6%)]	Loss: 113.108719
Train Epoch: 4 [5120/60000 (9%)]	Loss: 114.330338
Train Epoch: 4 [6400/60000 (11%)]	Loss: 109.400864
Train Epoch: 4 [7680/60000 (13%)]	Loss: 109.769531
Train Epoch: 4 [8960/60000 (15%)]	Loss: 108.232147
Train Epoch: 4 [10240/60000 (17%)]	Loss: 110.054840
Train Epoch: 4 [11520/60000 (19%)]	Loss: 112.566544
Train Epoch: 4 [12800/60000 (21%)]	Loss: 112.993256
Train Epoch: 4 [14080/60000 (24%)]	Loss: 108.107437
Train Epoch: 4 [15360/60000 (26%)]	Loss: 113.620995
Train Epoch: 4 [16640/60000 (28%)]	Loss: 110.397255
Train Epoch: 4 [17920/60000 (30%)]	Loss: 112.880882
Train Epoch: 4 [19200/60000 (32%)]	Loss: 109.503960
Train Epoch: 4 [20480/60000 (34%)]	Loss: 111.327827
Train Epoch: 4 [21760/60000 (36%)]	Loss: 111.587654
Train Epoch: 4 [23040/60000 (38%)]	Loss: 110.508644
Train Epoch: 4 [24320/60000 (41%)]	Loss: 109.556984
Train Epoch: 4 [25600/60000 (43%)]	Loss: 110.332382
Train Epoch: 4 [26880/60000 (45%)]	Loss: 106.482376
Train Epoch: 4 [28160/60000 (47%)]	Loss: 110.120041
Train Epoch: 4 [29440/60000 (49%)]	Loss: 112.343681
Train Epoch: 4 [30720/60000 (51%)]	Loss: 116.212082
Train Epoch: 4 [32000/60000 (53%)]	Loss: 113.023643
Train Epoch: 4 [33280/60000 (56%)]	Loss: 115.296989
Train Epoch: 4 [34560/60000 (58%)]	Loss: 115.880646
Train Epoch: 4 [35840/60000 (60%)]	Loss: 110.867889
Train Epoch: 4 [37120/60000 (62%)]	Loss: 118.023071
Train Epoch: 4 [38400/60000 (64%)]	Loss: 111.896591
Train Epoch: 4 [39680/60000 (66%)]	Loss: 112.922737
Train Epoch: 4 [40960/60000 (68%)]	Loss: 111.237991
Train Epoch: 4 [42240/60000 (71%)]	Loss: 109.654015
Train Epoch: 4 [43520/60000 (73%)]	Loss: 110.947433
Train Epoch: 4 [44800/60000 (75%)]	Loss: 116.790672
Train Epoch: 4 [46080/60000 (77%)]	Loss: 114.991898
Train Epoch: 4 [47360/60000 (79%)]	Loss: 109.275803
Train Epoch: 4 [48640/60000 (81%)]	Loss: 111.569618
Train Epoch: 4 [49920/60000 (83%)]	Loss: 108.827454
Train Epoch: 4 [51200/60000 (85%)]	Loss: 112.577248
Train Epoch: 4 [52480/60000 (88%)]	Loss: 110.475258
Train Epoch: 4 [53760/60000 (90%)]	Loss: 111.994843
Train Epoch: 4 [55040/60000 (92%)]	Loss: 109.607323
Train Epoch: 4 [56320/60000 (94%)]	Loss: 113.207420
Train Epoch: 4 [57600/60000 (96%)]	Loss: 104.560669
Train Epoch: 4 [58880/60000 (98%)]	Loss: 112.314743
====> Epoch: 4 Average loss: 111.4615
====> Test set loss: 109.8327
Train Epoch: 5 [0/60000 (0%)]	Loss: 112.073753
Train Epoch: 5 [1280/60000 (2%)]	Loss: 111.532372
Train Epoch: 5 [2560/60000 (4%)]	Loss: 109.342422
Train Epoch: 5 [3840/60000 (6%)]	Loss: 108.869797
Train Epoch: 5 [5120/60000 (9%)]	Loss: 111.045822
Train Epoch: 5 [6400/60000 (11%)]	Loss: 107.516167
Train Epoch: 5 [7680/60000 (13%)]	Loss: 107.687492
Train Epoch: 5 [8960/60000 (15%)]	Loss: 109.252014
Train Epoch: 5 [10240/60000 (17%)]	Loss: 104.485489
Train Epoch: 5 [11520/60000 (19%)]	Loss: 105.452713
Train Epoch: 5 [12800/60000 (21%)]	Loss: 111.727669
Train Epoch: 5 [14080/60000 (24%)]	Loss: 111.459045
Train Epoch: 5 [15360/60000 (26%)]	Loss: 109.590355
Train Epoch: 5 [16640/60000 (28%)]	Loss: 114.388947
Train Epoch: 5 [17920/60000 (30%)]	Loss: 105.345375
Train Epoch: 5 [19200/60000 (32%)]	Loss: 111.455696
Train Epoch: 5 [20480/60000 (34%)]	Loss: 104.604446
Train Epoch: 5 [21760/60000 (36%)]	Loss: 111.550591
Train Epoch: 5 [23040/60000 (38%)]	Loss: 114.413567
Train Epoch: 5 [24320/60000 (41%)]	Loss: 109.043129
Train Epoch: 5 [25600/60000 (43%)]	Loss: 109.885406
Train Epoch: 5 [26880/60000 (45%)]	Loss: 109.156448
Train Epoch: 5 [28160/60000 (47%)]	Loss: 109.116272
Train Epoch: 5 [29440/60000 (49%)]	Loss: 108.048279
Train Epoch: 5 [30720/60000 (51%)]	Loss: 108.823677
Train Epoch: 5 [32000/60000 (53%)]	Loss: 106.082260
Train Epoch: 5 [33280/60000 (56%)]	Loss: 107.350105
Train Epoch: 5 [34560/60000 (58%)]	Loss: 110.000595
Train Epoch: 5 [35840/60000 (60%)]	Loss: 105.043442
Train Epoch: 5 [37120/60000 (62%)]	Loss: 113.160645
Train Epoch: 5 [38400/60000 (64%)]	Loss: 106.381134
Train Epoch: 5 [39680/60000 (66%)]	Loss: 110.924744
Train Epoch: 5 [40960/60000 (68%)]	Loss: 108.307648
Train Epoch: 5 [42240/60000 (71%)]	Loss: 107.555405
Train Epoch: 5 [43520/60000 (73%)]	Loss: 116.135147
Train Epoch: 5 [44800/60000 (75%)]	Loss: 112.156097
Train Epoch: 5 [46080/60000 (77%)]	Loss: 108.219505
Train Epoch: 5 [47360/60000 (79%)]	Loss: 111.838013
Train Epoch: 5 [48640/60000 (81%)]	Loss: 107.377892
Train Epoch: 5 [49920/60000 (83%)]	Loss: 111.830711
Train Epoch: 5 [51200/60000 (85%)]	Loss: 110.929153
Train Epoch: 5 [52480/60000 (88%)]	Loss: 107.224266
Train Epoch: 5 [53760/60000 (90%)]	Loss: 109.807671
Train Epoch: 5 [55040/60000 (92%)]	Loss: 111.196030
Train Epoch: 5 [56320/60000 (94%)]	Loss: 107.910248
Train Epoch: 5 [57600/60000 (96%)]	Loss: 113.975937
Train Epoch: 5 [58880/60000 (98%)]	Loss: 109.875504
====> Epoch: 5 Average loss: 109.7301
====> Test set loss: 108.2571
Train Epoch: 6 [0/60000 (0%)]	Loss: 107.343864
Train Epoch: 6 [1280/60000 (2%)]	Loss: 114.818344
Train Epoch: 6 [2560/60000 (4%)]	Loss: 110.746643
Train Epoch: 6 [3840/60000 (6%)]	Loss: 111.913910
Train Epoch: 6 [5120/60000 (9%)]	Loss: 105.760796
Train Epoch: 6 [6400/60000 (11%)]	Loss: 108.697807
Train Epoch: 6 [7680/60000 (13%)]	Loss: 112.035004
Train Epoch: 6 [8960/60000 (15%)]	Loss: 107.504776
Train Epoch: 6 [10240/60000 (17%)]	Loss: 106.934715
Train Epoch: 6 [11520/60000 (19%)]	Loss: 112.159637
Train Epoch: 6 [12800/60000 (21%)]	Loss: 108.206940
Train Epoch: 6 [14080/60000 (24%)]	Loss: 109.855774
Train Epoch: 6 [15360/60000 (26%)]	Loss: 110.038200
Train Epoch: 6 [16640/60000 (28%)]	Loss: 106.746841
Train Epoch: 6 [17920/60000 (30%)]	Loss: 107.806168
Train Epoch: 6 [19200/60000 (32%)]	Loss: 107.567978
Train Epoch: 6 [20480/60000 (34%)]	Loss: 112.511749
Train Epoch: 6 [21760/60000 (36%)]	Loss: 103.775406
Train Epoch: 6 [23040/60000 (38%)]	Loss: 108.319374
Train Epoch: 6 [24320/60000 (41%)]	Loss: 112.178696
Train Epoch: 6 [25600/60000 (43%)]	Loss: 106.815979
Train Epoch: 6 [26880/60000 (45%)]	Loss: 108.435425
Train Epoch: 6 [28160/60000 (47%)]	Loss: 107.682892
Train Epoch: 6 [29440/60000 (49%)]	Loss: 110.012367
Train Epoch: 6 [30720/60000 (51%)]	Loss: 105.665665
Train Epoch: 6 [32000/60000 (53%)]	Loss: 109.654823
Train Epoch: 6 [33280/60000 (56%)]	Loss: 112.537689
Train Epoch: 6 [34560/60000 (58%)]	Loss: 107.465279
Train Epoch: 6 [35840/60000 (60%)]	Loss: 114.428680
Train Epoch: 6 [37120/60000 (62%)]	Loss: 107.931778
Train Epoch: 6 [38400/60000 (64%)]	Loss: 107.128380
Train Epoch: 6 [39680/60000 (66%)]	Loss: 106.038666
Train Epoch: 6 [40960/60000 (68%)]	Loss: 114.147682
Train Epoch: 6 [42240/60000 (71%)]	Loss: 108.996941
Train Epoch: 6 [43520/60000 (73%)]	Loss: 105.756721
Train Epoch: 6 [44800/60000 (75%)]	Loss: 110.644035
Train Epoch: 6 [46080/60000 (77%)]	Loss: 109.968216
Train Epoch: 6 [47360/60000 (79%)]	Loss: 108.139145
Train Epoch: 6 [48640/60000 (81%)]	Loss: 111.644402
Train Epoch: 6 [49920/60000 (83%)]	Loss: 109.371246
Train Epoch: 6 [51200/60000 (85%)]	Loss: 106.631424
Train Epoch: 6 [52480/60000 (88%)]	Loss: 105.227966
Train Epoch: 6 [53760/60000 (90%)]	Loss: 107.877357
Train Epoch: 6 [55040/60000 (92%)]	Loss: 105.116882
Train Epoch: 6 [56320/60000 (94%)]	Loss: 104.566238
Train Epoch: 6 [57600/60000 (96%)]	Loss: 109.172668
Train Epoch: 6 [58880/60000 (98%)]	Loss: 114.297127
====> Epoch: 6 Average loss: 108.4609
====> Test set loss: 107.7398
Train Epoch: 7 [0/60000 (0%)]	Loss: 107.775452
Train Epoch: 7 [1280/60000 (2%)]	Loss: 107.492325
Train Epoch: 7 [2560/60000 (4%)]	Loss: 105.241226
Train Epoch: 7 [3840/60000 (6%)]	Loss: 106.344795
Train Epoch: 7 [5120/60000 (9%)]	Loss: 110.051880
Train Epoch: 7 [6400/60000 (11%)]	Loss: 106.357338
Train Epoch: 7 [7680/60000 (13%)]	Loss: 107.893356
Train Epoch: 7 [8960/60000 (15%)]	Loss: 103.579773
Train Epoch: 7 [10240/60000 (17%)]	Loss: 110.693787
Train Epoch: 7 [11520/60000 (19%)]	Loss: 108.255066
Train Epoch: 7 [12800/60000 (21%)]	Loss: 110.445496
Train Epoch: 7 [14080/60000 (24%)]	Loss: 107.489288
Train Epoch: 7 [15360/60000 (26%)]	Loss: 109.844757
Train Epoch: 7 [16640/60000 (28%)]	Loss: 107.494072
Train Epoch: 7 [17920/60000 (30%)]	Loss: 104.364349
Train Epoch: 7 [19200/60000 (32%)]	Loss: 107.626572
Train Epoch: 7 [20480/60000 (34%)]	Loss: 107.067833
Train Epoch: 7 [21760/60000 (36%)]	Loss: 104.899918
Train Epoch: 7 [23040/60000 (38%)]	Loss: 110.136276
Train Epoch: 7 [24320/60000 (41%)]	Loss: 108.794113
Train Epoch: 7 [25600/60000 (43%)]	Loss: 106.500549
Train Epoch: 7 [26880/60000 (45%)]	Loss: 110.268196
Train Epoch: 7 [28160/60000 (47%)]	Loss: 112.012604
Train Epoch: 7 [29440/60000 (49%)]	Loss: 107.585968
Train Epoch: 7 [30720/60000 (51%)]	Loss: 105.509041
Train Epoch: 7 [32000/60000 (53%)]	Loss: 105.274773
Train Epoch: 7 [33280/60000 (56%)]	Loss: 107.773346
Train Epoch: 7 [34560/60000 (58%)]	Loss: 107.403305
Train Epoch: 7 [35840/60000 (60%)]	Loss: 114.204453
Train Epoch: 7 [37120/60000 (62%)]	Loss: 108.041077
Train Epoch: 7 [38400/60000 (64%)]	Loss: 107.994873
Train Epoch: 7 [39680/60000 (66%)]	Loss: 108.194275
Train Epoch: 7 [40960/60000 (68%)]	Loss: 109.383011
Train Epoch: 7 [42240/60000 (71%)]	Loss: 108.869629
Train Epoch: 7 [43520/60000 (73%)]	Loss: 110.435944
Train Epoch: 7 [44800/60000 (75%)]	Loss: 110.803528
Train Epoch: 7 [46080/60000 (77%)]	Loss: 107.733536
Train Epoch: 7 [47360/60000 (79%)]	Loss: 108.004364
Train Epoch: 7 [48640/60000 (81%)]	Loss: 106.265877
Train Epoch: 7 [49920/60000 (83%)]	Loss: 106.197929
Train Epoch: 7 [51200/60000 (85%)]	Loss: 110.814148
Train Epoch: 7 [52480/60000 (88%)]	Loss: 106.743446
Train Epoch: 7 [53760/60000 (90%)]	Loss: 106.266617
Train Epoch: 7 [55040/60000 (92%)]	Loss: 109.933411
Train Epoch: 7 [56320/60000 (94%)]	Loss: 105.292160
Train Epoch: 7 [57600/60000 (96%)]	Loss: 106.509308
Train Epoch: 7 [58880/60000 (98%)]	Loss: 107.421097
====> Epoch: 7 Average loss: 107.6333
====> Test set loss: 106.6624
Train Epoch: 8 [0/60000 (0%)]	Loss: 104.282013
Train Epoch: 8 [1280/60000 (2%)]	Loss: 108.213760
Train Epoch: 8 [2560/60000 (4%)]	Loss: 108.050079
Train Epoch: 8 [3840/60000 (6%)]	Loss: 108.977226
Train Epoch: 8 [5120/60000 (9%)]	Loss: 103.240173
Train Epoch: 8 [6400/60000 (11%)]	Loss: 106.010635
Train Epoch: 8 [7680/60000 (13%)]	Loss: 103.598854
Train Epoch: 8 [8960/60000 (15%)]	Loss: 109.260712
Train Epoch: 8 [10240/60000 (17%)]	Loss: 109.694244
Train Epoch: 8 [11520/60000 (19%)]	Loss: 106.392357
Train Epoch: 8 [12800/60000 (21%)]	Loss: 106.334564
Train Epoch: 8 [14080/60000 (24%)]	Loss: 109.013672
Train Epoch: 8 [15360/60000 (26%)]	Loss: 106.745750
Train Epoch: 8 [16640/60000 (28%)]	Loss: 110.892197
Train Epoch: 8 [17920/60000 (30%)]	Loss: 104.415947
Train Epoch: 8 [19200/60000 (32%)]	Loss: 105.543808
Train Epoch: 8 [20480/60000 (34%)]	Loss: 109.544968
Train Epoch: 8 [21760/60000 (36%)]	Loss: 105.716278
Train Epoch: 8 [23040/60000 (38%)]	Loss: 106.205444
Train Epoch: 8 [24320/60000 (41%)]	Loss: 104.008667
Train Epoch: 8 [25600/60000 (43%)]	Loss: 112.770988
Train Epoch: 8 [26880/60000 (45%)]	Loss: 106.218185
Train Epoch: 8 [28160/60000 (47%)]	Loss: 104.728867
Train Epoch: 8 [29440/60000 (49%)]	Loss: 106.983109
Train Epoch: 8 [30720/60000 (51%)]	Loss: 106.087448
Train Epoch: 8 [32000/60000 (53%)]	Loss: 105.108490
Train Epoch: 8 [33280/60000 (56%)]	Loss: 106.459686
Train Epoch: 8 [34560/60000 (58%)]	Loss: 107.093170
Train Epoch: 8 [35840/60000 (60%)]	Loss: 106.406204
Train Epoch: 8 [37120/60000 (62%)]	Loss: 100.744308
Train Epoch: 8 [38400/60000 (64%)]	Loss: 105.651672
Train Epoch: 8 [39680/60000 (66%)]	Loss: 103.685898
Train Epoch: 8 [40960/60000 (68%)]	Loss: 109.832199
Train Epoch: 8 [42240/60000 (71%)]	Loss: 108.710754
Train Epoch: 8 [43520/60000 (73%)]	Loss: 110.769653
Train Epoch: 8 [44800/60000 (75%)]	Loss: 105.754723
Train Epoch: 8 [46080/60000 (77%)]	Loss: 106.839546
Train Epoch: 8 [47360/60000 (79%)]	Loss: 107.200676
Train Epoch: 8 [48640/60000 (81%)]	Loss: 108.302170
Train Epoch: 8 [49920/60000 (83%)]	Loss: 104.894974
Train Epoch: 8 [51200/60000 (85%)]	Loss: 106.690117
Train Epoch: 8 [52480/60000 (88%)]	Loss: 104.621490
Train Epoch: 8 [53760/60000 (90%)]	Loss: 103.435555
Train Epoch: 8 [55040/60000 (92%)]	Loss: 106.019623
Train Epoch: 8 [56320/60000 (94%)]	Loss: 110.000832
Train Epoch: 8 [57600/60000 (96%)]	Loss: 106.232376
Train Epoch: 8 [58880/60000 (98%)]	Loss: 108.623726
====> Epoch: 8 Average loss: 106.9833
====> Test set loss: 106.3478
Train Epoch: 9 [0/60000 (0%)]	Loss: 109.482864
Train Epoch: 9 [1280/60000 (2%)]	Loss: 104.982178
Train Epoch: 9 [2560/60000 (4%)]	Loss: 103.968666
Train Epoch: 9 [3840/60000 (6%)]	Loss: 107.319611
Train Epoch: 9 [5120/60000 (9%)]	Loss: 105.041748
Train Epoch: 9 [6400/60000 (11%)]	Loss: 108.193192
Train Epoch: 9 [7680/60000 (13%)]	Loss: 110.090332
Train Epoch: 9 [8960/60000 (15%)]	Loss: 101.559143
Train Epoch: 9 [10240/60000 (17%)]	Loss: 107.606018
Train Epoch: 9 [11520/60000 (19%)]	Loss: 108.879150
Train Epoch: 9 [12800/60000 (21%)]	Loss: 110.541458
Train Epoch: 9 [14080/60000 (24%)]	Loss: 107.139160
Train Epoch: 9 [15360/60000 (26%)]	Loss: 105.883224
Train Epoch: 9 [16640/60000 (28%)]	Loss: 107.395996
Train Epoch: 9 [17920/60000 (30%)]	Loss: 110.612289
Train Epoch: 9 [19200/60000 (32%)]	Loss: 105.373848
Train Epoch: 9 [20480/60000 (34%)]	Loss: 105.545036
Train Epoch: 9 [21760/60000 (36%)]	Loss: 105.042809
Train Epoch: 9 [23040/60000 (38%)]	Loss: 106.679626
Train Epoch: 9 [24320/60000 (41%)]	Loss: 107.464371
Train Epoch: 9 [25600/60000 (43%)]	Loss: 109.063820
Train Epoch: 9 [26880/60000 (45%)]	Loss: 107.747787
Train Epoch: 9 [28160/60000 (47%)]	Loss: 110.239822
Train Epoch: 9 [29440/60000 (49%)]	Loss: 109.813591
Train Epoch: 9 [30720/60000 (51%)]	Loss: 107.135391
Train Epoch: 9 [32000/60000 (53%)]	Loss: 104.315948
Train Epoch: 9 [33280/60000 (56%)]	Loss: 108.011360
Train Epoch: 9 [34560/60000 (58%)]	Loss: 105.661293
Train Epoch: 9 [35840/60000 (60%)]	Loss: 103.765953
Train Epoch: 9 [37120/60000 (62%)]	Loss: 105.084007
Train Epoch: 9 [38400/60000 (64%)]	Loss: 106.025528
Train Epoch: 9 [39680/60000 (66%)]	Loss: 109.173431
Train Epoch: 9 [40960/60000 (68%)]	Loss: 106.138489
Train Epoch: 9 [42240/60000 (71%)]	Loss: 107.072021
Train Epoch: 9 [43520/60000 (73%)]	Loss: 104.435547
Train Epoch: 9 [44800/60000 (75%)]	Loss: 104.883575
Train Epoch: 9 [46080/60000 (77%)]	Loss: 108.266541
Train Epoch: 9 [47360/60000 (79%)]	Loss: 104.906242
Train Epoch: 9 [48640/60000 (81%)]	Loss: 105.954987
Train Epoch: 9 [49920/60000 (83%)]	Loss: 108.291946
Train Epoch: 9 [51200/60000 (85%)]	Loss: 103.468956
Train Epoch: 9 [52480/60000 (88%)]	Loss: 106.164993
Train Epoch: 9 [53760/60000 (90%)]	Loss: 108.943710
Train Epoch: 9 [55040/60000 (92%)]	Loss: 108.925560
Train Epoch: 9 [56320/60000 (94%)]	Loss: 105.144211
Train Epoch: 9 [57600/60000 (96%)]	Loss: 108.643341
Train Epoch: 9 [58880/60000 (98%)]	Loss: 107.633087
====> Epoch: 9 Average loss: 106.4913
====> Test set loss: 106.0310
Train Epoch: 10 [0/60000 (0%)]	Loss: 106.673851
Train Epoch: 10 [1280/60000 (2%)]	Loss: 107.545097
Train Epoch: 10 [2560/60000 (4%)]	Loss: 106.046997
Train Epoch: 10 [3840/60000 (6%)]	Loss: 106.580338
Train Epoch: 10 [5120/60000 (9%)]	Loss: 105.917198
Train Epoch: 10 [6400/60000 (11%)]	Loss: 108.315979
Train Epoch: 10 [7680/60000 (13%)]	Loss: 106.795692
Train Epoch: 10 [8960/60000 (15%)]	Loss: 107.841629
Train Epoch: 10 [10240/60000 (17%)]	Loss: 107.074341
Train Epoch: 10 [11520/60000 (19%)]	Loss: 106.862991
Train Epoch: 10 [12800/60000 (21%)]	Loss: 106.545090
Train Epoch: 10 [14080/60000 (24%)]	Loss: 106.107475
Train Epoch: 10 [15360/60000 (26%)]	Loss: 105.007050
Train Epoch: 10 [16640/60000 (28%)]	Loss: 105.871002
Train Epoch: 10 [17920/60000 (30%)]	Loss: 105.932457
Train Epoch: 10 [19200/60000 (32%)]	Loss: 106.033096
Train Epoch: 10 [20480/60000 (34%)]	Loss: 103.763214
Train Epoch: 10 [21760/60000 (36%)]	Loss: 105.398849
Train Epoch: 10 [23040/60000 (38%)]	Loss: 108.041595
Train Epoch: 10 [24320/60000 (41%)]	Loss: 104.599739
Train Epoch: 10 [25600/60000 (43%)]	Loss: 105.479019
Train Epoch: 10 [26880/60000 (45%)]	Loss: 107.283585
Train Epoch: 10 [28160/60000 (47%)]	Loss: 104.393433
Train Epoch: 10 [29440/60000 (49%)]	Loss: 107.194580
Train Epoch: 10 [30720/60000 (51%)]	Loss: 101.851852
Train Epoch: 10 [32000/60000 (53%)]	Loss: 107.114189
Train Epoch: 10 [33280/60000 (56%)]	Loss: 109.063438
Train Epoch: 10 [34560/60000 (58%)]	Loss: 110.307510
Train Epoch: 10 [35840/60000 (60%)]	Loss: 106.638855
Train Epoch: 10 [37120/60000 (62%)]	Loss: 104.242119
Train Epoch: 10 [38400/60000 (64%)]	Loss: 108.356590
Train Epoch: 10 [39680/60000 (66%)]	Loss: 106.620712
Train Epoch: 10 [40960/60000 (68%)]	Loss: 103.209915
Train Epoch: 10 [42240/60000 (71%)]	Loss: 106.640671
Train Epoch: 10 [43520/60000 (73%)]	Loss: 103.255676
Train Epoch: 10 [44800/60000 (75%)]	Loss: 106.519196
Train Epoch: 10 [46080/60000 (77%)]	Loss: 108.512154
Train Epoch: 10 [47360/60000 (79%)]	Loss: 107.208138
Train Epoch: 10 [48640/60000 (81%)]	Loss: 98.118935
Train Epoch: 10 [49920/60000 (83%)]	Loss: 107.784035
Train Epoch: 10 [51200/60000 (85%)]	Loss: 108.579247
Train Epoch: 10 [52480/60000 (88%)]	Loss: 106.951180
Train Epoch: 10 [53760/60000 (90%)]	Loss: 104.350800
Train Epoch: 10 [55040/60000 (92%)]	Loss: 104.927879
Train Epoch: 10 [56320/60000 (94%)]	Loss: 106.438988
Train Epoch: 10 [57600/60000 (96%)]	Loss: 106.678276
Train Epoch: 10 [58880/60000 (98%)]	Loss: 106.996048
====> Epoch: 10 Average loss: 106.0849
====> Test set loss: 105.6188

```

Thanks!
Federico